### PR TITLE
Feature/item service

### DIFF
--- a/app/Http/Controllers/MyPageController.php
+++ b/app/Http/Controllers/MyPageController.php
@@ -7,29 +7,14 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Pagination\LengthAwarePaginator;
 use App\Models\Item;
 use Inertia\Inertia;
+use App\Services\ItemService;
 
 class MyPageController extends Controller
 {
     public function index(Request $request) {
-        $items = Auth::user()->items;
-
-        // $items配列内に 'is_like' フラグを追加
-        $items->map(function ($item) {
-            $item['is_like'] = false;
-            return $item;
-        });
-
-        // お気に入り登録商品を判別
-        if(Auth::user()) {
-            $like_item_ids = Auth::user()->likeItems->pluck('id')->toArray();
-
-            // お気に入り商品なら$item['is_like']をtrueへ変更
-            foreach ($items as $item) {
-                if (in_array($item->id, $like_item_ids)) {
-                    $item['is_like'] = true;
-                }
-            }
-        }
+        // 出品済み商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
+        $item_service = new ItemService;
+        $items = $item_service->getSellItemsWithLike();
 
         // ページネーション
         $items = new LengthAwarePaginator
@@ -47,25 +32,9 @@ class MyPageController extends Controller
     }
 
     public function showPurchased(Request $request) {
-        $items = Auth::user()->purchasedItems;
-
-        // $items配列内に 'is_like' フラグを追加
-        $items->map(function ($item) {
-            $item['is_like'] = false;
-            return $item;
-        });
-
-        // お気に入り登録商品を判別
-        if(Auth::user()) {
-            $like_item_ids = Auth::user()->likeItems->pluck('id')->toArray();
-
-            // お気に入り商品なら$item['is_like']をtrueへ変更
-            foreach ($items as $item) {
-                if (in_array($item->id, $like_item_ids)) {
-                    $item['is_like'] = true;
-                }
-            }
-        }
+        // 購入済み商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
+        $item_service = new ItemService;
+        $items = $item_service->getPurchasedItemsWithLike();
 
         // ページネーション
         $items = new LengthAwarePaginator

--- a/app/Http/Controllers/TopPageController.php
+++ b/app/Http/Controllers/TopPageController.php
@@ -8,29 +8,14 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use App\Models\Item;
 use Inertia\Inertia;
 use Inertia\Response;
+use App\Services\ItemService;
 
 class TopPageController extends Controller
 {
     public function index(Request $request) {
-        $items = Item::all();
-
-        // $items配列内に 'is_like' フラグを追加
-        $items->map(function ($item) {
-            $item['is_like'] = false;
-            return $item;
-        });
-
-        // お気に入り登録商品を判別
-        if(Auth::user()) {
-            $like_item_ids = Auth::user()->likeItems->pluck('id')->toArray();
-
-            // お気に入り商品なら$item['is_like']をtrueへ変更
-            foreach ($items as $item) {
-                if (in_array($item->id, $like_item_ids)) {
-                    $item['is_like'] = true;
-                }
-            }
-        }
+        // 全商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
+        $item_service = new ItemService;
+        $items = $item_service->getAllItemsWithLike();
 
         // ページネーション
         $items = new LengthAwarePaginator
@@ -48,13 +33,9 @@ class TopPageController extends Controller
     }
 
     public function showMylist(Request $request) {
-        $items = Auth::user()->likeItems;
-
-        // $items配列内に 'is_like' フラグを追加
-        $items->map(function ($item) {
-            $item['is_like'] = true;
-            return $item;
-        });
+        // お気に入り登録商品を取得
+        $item_service = new ItemService;
+        $items = $item_service->getLikeItemsWithLike();
 
         // ページネーション
         $items = new LengthAwarePaginator

--- a/app/Http/Controllers/TopPageController.php
+++ b/app/Http/Controllers/TopPageController.php
@@ -15,7 +15,11 @@ class TopPageController extends Controller
     public function index(Request $request) {
         // 全商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
         $item_service = new ItemService;
-        $items = $item_service->getAllItemsWithLike();
+        if ($request->searchWord) {
+            $items = $item_service->searchItemsWithLike($request->searchWord);
+        } else {
+            $items = $item_service->getAllItemsWithLike();
+        }
 
         // ページネーション
         $items = new LengthAwarePaginator

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    protected $guarded = ['id'];
+
+    public function items () {
+        return $this->belongsToMany('App\Models\Item');
+    }
+}

--- a/app/Models/Category_item.php
+++ b/app/Models/Category_item.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category_item extends Model
+{
+    /** @use HasFactory<\Database\Factories\CategoryItemFactory> */
+    use HasFactory;
+
+    protected $guarded = ['id'];
+}

--- a/app/Models/Condition.php
+++ b/app/Models/Condition.php
@@ -7,4 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 class Condition extends Model
 {
     protected $guarded = ['id'];
+
+    public function items() {
+        return $this->hasMany('App\Models\Item');
+    }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class Item extends Model
 {
@@ -22,5 +23,15 @@ class Item extends Model
 
     public function purchasedUser() {
         return $this->belongsToMany('App\Models\User', 'sold_items');
+    }
+
+    /**
+     * お気に入り登録された商品かどうかの判別メソッド
+     *
+     * @return boolean
+     */
+    public function isLike() : bool {
+        $like = $this->likes->where('user_id', Auth::user()->id);
+        return $like->isNotEmpty();
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -25,6 +25,10 @@ class Item extends Model
         return $this->belongsToMany('App\Models\User', 'sold_items');
     }
 
+    public function categories () {
+        return $this->belongsToMany('App\Models\Category');
+    }
+
     /**
      * お気に入り登録された商品かどうかの判別メソッド
      *

--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -1,0 +1,93 @@
+<?php
+namespace App\Services;
+
+use \Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Item;
+
+class ItemService
+{
+    private $items;
+
+    /**
+     * 全商品を取得する（お気に入り商品判別フラグ付き）
+     *
+     * @return Collection
+     */
+    public function getAllItemsWithLike() : Collection {
+        $this->items = Item::all();
+
+        // is_likeフラグを付与
+        $this->withLike();
+
+        return $this->items;
+    }
+
+    /**
+     * お気に入り登録商品を取得する
+     *
+     * @return Collection
+     */
+    public function getLikeItemsWithLike() : Collection {
+        $this->items = Auth::user()->likeItems;
+
+        // is_likeフラグを付与
+        $this->withLike();
+
+        return $this->items;
+    }
+
+    /**
+     * 自身が出品した商品を取得する（お気に入り商品判別フラグ付き）
+     *
+     * @return Collection
+     */
+    public function getSellItemsWithLike() : Collection {
+        $this->items = Auth::user()->items;
+
+        // is_likeフラグを付与
+        $this->withLike();
+
+        return $this->items;
+    }
+
+    /**
+     * 自身が購入した商品を取得する（お気に入り商品判別フラグ付き）
+     *
+     * @return Collection
+     */
+    public function getPurchasedItemsWithLike() : Collection {
+        $this->items = Auth::user()->purchasedItems;
+
+        // is_likeフラグを付与
+        $this->withLike();
+
+        return $this->items;
+    }
+
+    /**
+     * 文字列検索して該当する商品を取得する
+     * （検索対象：商品名／商品説明文／カテゴリー／商品の状態）
+     *
+     * @param string $search_word 検索文字列
+     * @return Collection
+     */
+    public function searchItemsWithLike(string $search_word) : Collection {
+        // ここに検索処理を書く
+
+        return $this->items;
+    }
+
+    /**
+     * itemsにお気に入り商品かどうかの判別フラグ is_like を付与する
+     *
+     * @return void
+     */
+    private function withLike() : void {
+        // $items配列内に 'is_like' フラグを追加
+        $this->items->map(function ($item) {
+            $item['is_like'] = $item->isLike();
+            return $item;
+        });
+    }
+}

--- a/database/migrations/2024_12_25_140007_create_categories_table.php
+++ b/database/migrations/2024_12_25_140007_create_categories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamp('created_at')->useCurrent()->nullable();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_12_25_140306_create_category_item_table.php
+++ b/database/migrations/2024_12_25_140306_create_category_item_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('category_item', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('item_id')->constrained();
+            $table->foreignId('category_id')->constrained();
+            $table->unique(['item_id', 'category_id']);
+            $table->timestamp('created_at')->useCurrent()->nullable();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('category_item');
+    }
+};

--- a/database/seeders/CategoryItemSeeder.php
+++ b/database/seeders/CategoryItemSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use App\Models\Item;
+use App\Models\Category;
+
+class CategoryItemSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // item_id と category_id の組み合わせを被りなくランダム取得
+        $item_ids = Item::all()->pluck('id');
+        $category_ids = Category::all()->pluck('id');
+        $matrix = $item_ids->crossJoin($category_ids);
+        $key_pairs = fake()->unique()->randomElements($matrix, 70);
+
+        foreach ($key_pairs as $key_pair) {
+            $param = [
+                'item_id' => $key_pair[0],
+                'category_id' => $key_pair[1],
+            ];
+            DB::table('category_item')->insert($param);
+        }
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $param = [
+            ['name' => 'レディース'],
+            ['name' => 'メンズ'],
+            ['name' => 'コスメ/美容'],
+            ['name' => 'キッズ/ベビー/マタニティ'],
+            ['name' => 'エンタメ/ホビー'],
+            ['name' => '楽器'],
+            ['name' => 'チケット'],
+            ['name' => 'インテリア/住まい/日用品'],
+            ['name' => 'スマホ/家電/カメラ'],
+            ['name' => 'ハンドメイド'],
+            ['name' => '食品/飲料/酒'],
+            ['name' => 'スポーツ/アウトドア'],
+            ['name' => '自動車/バイク'],
+            ['name' => 'その他'],
+        ];
+        DB::table('categories')->insert($param);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Category;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -10,6 +11,8 @@ use Database\Seeders\ConditionSeeder;
 use Database\Seeders\ItemSeeder;
 use Database\Seeders\PaymentMethodSeeder;
 use Database\Seeders\ProfileSeeder;
+use Database\Seeders\CategorySeeder;
+use Database\Seeders\CategoryItemSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -28,5 +31,7 @@ class DatabaseSeeder extends Seeder
         $this->call(ConditionSeeder::class);
         $this->call(ItemSeeder::class);
         $this->call(PaymentMethodSeeder::class);
+        $this->call(CategorySeeder::class);
+        $this->call(CategoryItemSeeder::class);
     }
 }

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use App\Models\Condition;
 
 class ItemSeeder extends Seeder
 {
@@ -13,13 +14,15 @@ class ItemSeeder extends Seeder
      */
     public function run(): void
     {
+        $condition_num = Condition::count();
+
         for ($i=1; $i<=50; $i++) {
             $param = [
                 'name' => "商品名_{$i}",
-                'price' => '1000',
+                'price' => (fake()->numberBetween(1, 100)) * 1000,
                 'description' => '商品詳細テキスト',
                 'image_url' => '/img/dummy_item.png',
-                'condition_id' => '1',
+                'condition_id' => fake()->numberBetween(1, $condition_num),
                 'user_id' => '1',
             ];
             DB::table('items')->insert($param);

--- a/resources/js/Components/SearchItems.vue
+++ b/resources/js/Components/SearchItems.vue
@@ -5,7 +5,7 @@ import { router } from '@inertiajs/vue3'
 const searchWord = ref('')
 
 function search() {
-    router.get('/', { word: searchWord.value })
+    router.get('/', { searchWord: searchWord.value })
 }
 </script>
 

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -26,7 +26,7 @@ onUnmounted(() => {
                     </Link>
                     <div class="flex gap-10">
                         <div>
-                            <!-- <SearchItems /> -->
+                            <SearchItems />
                         </div>
                         <nav class="flex items-center gap-10 text-white">
                             <NavLink :href="route('logout')" as="button" type="button" method="post">ログアウト</NavLink>


### PR DESCRIPTION
## 【概要】
コントローラー内で行っていた商品情報一覧の取得処理をサービスクラスへ分離
商品検索の対象となる「カテゴリ」のテーブルを併せて作成

## 【実装内容詳細】
- 以下モデル、テーブルの作成
	- Category
	- CategoryItem
- 上記テーブル用シーダーの作成
- サービスクラスの作成
	- ItemService.php
- 上記サービスクラスに以下処理を記述
	- 全商品取得メソッド
	- お気に入り登録商品取得メソッド
	- 出品済み商品取得メソッド
	- 購入済み商品取得メソッド
	- 文字列検索メソッド
	- お気に入り商品判別フラグ付与メソッド
- コントローラー内の商品一覧取得処理を上記サービスのメソッドに置き換え