### PR TITLE
商品検索後のページネーションを実装

### DIFF
--- a/app/Http/Controllers/TopPageController.php
+++ b/app/Http/Controllers/TopPageController.php
@@ -22,13 +22,17 @@ class TopPageController extends Controller
         }
 
         // ページネーション
+        $path = $request->url();
+        if ($request->searchWord) {
+            $path = $path . "/?searchWord=" . $request->searchWord;
+        }
         $items = new LengthAwarePaginator
         (
             $items->forPage($request->page, 20),
             $items->count(),
             20,
             $request->page,
-            ['path' => $request->url()]
+            ['path' => $path ]
         );
 
         return Inertia::render('Top', [


### PR DESCRIPTION
## 【概要】
商品検索後、検索状態を維持したままページネーション可能となるよう処理を追記

## 【実装内容詳細】
- TopPageControllerのindex()におけるページネーションのパスに検索文字列のクエリパラメータが含まれるよう変更