### PR TITLE
Feature/stripe checkout

### DIFF
--- a/app/Http/Controllers/Api/PurchaseController.php
+++ b/app/Http/Controllers/Api/PurchaseController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Stripe\StripeClient;
+
+class PurchaseController extends Controller
+{
+    public function createCheckoutSession(Request $request): JsonResponse {
+        $stripe = new StripeClient("sk_test_51QBad1Bli9nlS8GVTqk4Uty9r2jQqd3WwJlYOrZJZmNPZQWZBqPR4VOJNVPWaZMO88CJT7H9fDoXkJuIp6fTDo1K00UkjRgzAt");
+
+       //Checkoutセッション作成
+        $checkout = $stripe->checkout->sessions->create([
+            'line_items'             => [[
+                'price'    => 'price_1QdnKOBli9nlS8GV5hoD5foG',
+                'quantity' => 1,
+            ],
+            ],
+            'mode'                   => 'payment',
+            'customer'               => 'cus_RWr3vVgmr9PlMD',
+            'ui_mode' => 'embedded',
+            'return_url' => 'http://localhost/',
+            'redirect_on_completion'=> 'if_required',
+            'payment_method_options' => [
+                'card' => [
+                    'setup_future_usage' => 'on_session',
+                ],
+            ],
+            'payment_method_types'   => ['card']
+        ]);
+
+        return response()->json($checkout);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/framework": "^11.31",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
+        "stripe/stripe-php": "^16.4",
         "tightenco/ziggy": "^2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0a4229d98c0ec9cf0c5ca2e970baa0a",
+    "content-hash": "a1a2bfec2894af70aa99c1611f8ee139",
     "packages": [
         {
             "name": "brick/math",
@@ -3438,6 +3438,65 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v16.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "4aa86099f888db9368f5f778f29feb14e6294dfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/4aa86099f888db9368f5f778f29feb14e6294dfb",
+                "reference": "4aa86099f888db9368f5f778f29feb14e6294dfb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.5.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v16.4.0"
+            },
+            "time": "2024-12-18T23:42:15+00:00"
         },
         {
             "name": "symfony/clock",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "@stripe/stripe-js": "^5.4.0"
+            },
             "devDependencies": {
                 "@inertiajs/vue3": "^1.0.0",
                 "@tailwindcss/forms": "^0.5.3",
@@ -842,6 +845,14 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@stripe/stripe-js": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-5.4.0.tgz",
+            "integrity": "sha512-3tfMbSvLGB+OsJ2MsjWjWo+7sp29dwx+3+9kG/TEnZQJt+EwbF/Nomm43cSK+6oXZA9uhspgyrB+BbrPRumx4g==",
+            "engines": {
+                "node": ">=12.16"
+            }
         },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.9",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
         "tailwindcss": "^3.2.1",
         "vite": "^6.0",
         "vue": "^3.4.0"
+    },
+    "dependencies": {
+        "@stripe/stripe-js": "^5.4.0"
     }
 }

--- a/resources/js/Components/StripeCheckoutButton.vue
+++ b/resources/js/Components/StripeCheckoutButton.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import { loadStripe } from '@stripe/stripe-js'
+
+const props = defineProps({
+    itemId: Number,
+});
+
+const stripeKey = "pk_test_51QBad1Bli9nlS8GV0wskk4eK8OoTM6vLGUuQ7igRELuoB3B4YlbN4ubnUKFPaFeXeTqju80TN1vyXrMS7LWFY4zb00Pd2mQYT5";
+const checkout = ref(null);
+const open = ref(false);
+
+async function submit() {
+    open.value = true;
+
+    const stripe = await loadStripe(stripeKey);
+
+    await axios
+        .post('/api/purchase/' + props.itemId)
+        .then(async (res) => {
+            const tempCheckout = await stripe.initEmbeddedCheckout({
+                clientSecret: res.data.client_secret,
+            });
+            checkout.value = tempCheckout;
+            tempCheckout?.mount('#checkout');
+        });
+}
+
+async function hide() {
+    await checkout.value?.destroy();
+    open.value = false;
+}
+</script>
+
+<template>
+    <div>
+        <div>
+            <PrimaryButton @click="submit()">購入する</PrimaryButton>
+        </div>
+
+        <Teleport to="body">
+            <div
+                v-if="open"
+                class="fixed top-0 right-0 bottom-0 left-0 bg-[rgba(0,0,0,.3)]"
+            >
+                <div class="fixed top-1/2 left-1/2 z-50 bg-white translate-y-[-50%] translate-x-[-50%] drop-shadow-xl py-10 px-20 max-h-[85vh] overflow-auto">
+                    <div id="checkout"></div>
+                    <button @click="hide()" class="block w-3/4 mx-auto mt-10">Close</button>
+                </div>
+            </div>
+        </Teleport>
+    </div>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\MyPageController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ItemDetailController;
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\Api\PurchaseController;
 
 // Route::get('/', function () {
 //     return Inertia::render('Welcome', [
@@ -39,6 +40,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/mypage/profile', [ProfileController::class, 'update']);
     Route::get('/item/comment/{item_id}', [CommentController::class, 'index'])->name('item.comment');
     Route::post('/item/comment/{item_id}', [CommentController::class, 'store']);
+    Route::post('/api/purchase/{item_id}', [PurchaseController::class, 'createCheckoutSession']);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 【概要】
Stripe決済用の購入ボタンコンポーネント作成

## 【実装内容詳細】
- 以下をインストール
	- stripe-php
	- stripe-js
- 決済用セッション情報を作成するルーティングとそれに対応するコントローラーメソッドの追加
	- PurchaseController::class, 'createCheckoutSession'
- 決済ボタン用の以下コンポーネントを追加
	- StripeCheckoutButton.vue