### PR TITLE
Feature/change payment method

### DIFF
--- a/app/Http/Controllers/PurchaseController.php
+++ b/app/Http/Controllers/PurchaseController.php
@@ -6,14 +6,17 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use App\Services\ItemDetailService;
+use App\Models\PaymentMethod;
 
 class PurchaseController extends Controller
 {
     public function create(Request $request) {
         $item = ItemDetailService::getItemDetail($request->item_id);
+        $paymentMethods = PaymentMethod::all()->pluck('name', 'id');
 
         return Inertia::render('Purchase', [
-            'item' => $item
+            'item' => $item,
+            'paymentMethods' => $paymentMethods
         ]);
     }
 }

--- a/database/migrations/2024_12_20_163330_create_payment_methods_table.php
+++ b/database/migrations/2024_12_20_163330_create_payment_methods_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('payment_methods', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('payment_method_type');
             $table->timestamp('created_at')->useCurrent()->nullable();
             $table->timestamp('updated_at')->useCurrent()->nullable();
         });

--- a/database/seeders/PaymentMethodSeeder.php
+++ b/database/seeders/PaymentMethodSeeder.php
@@ -14,9 +14,18 @@ class PaymentMethodSeeder extends Seeder
     public function run(): void
     {
         $param = [
-            ['name' => 'クレジットカード決済'],
-            ['name' => 'コンビニ払い'],
-            ['name' => '銀行振込'],
+            [
+                'name' => 'クレジットカード決済',
+                'payment_method_type' => 'card'
+            ],
+            [
+                'name' => 'コンビニ払い',
+                'payment_method_type' => 'konbini'
+            ],
+            [
+                'name' => '銀行振込',
+                'payment_method_type' => 'customer_balance'
+            ],
         ];
         DB::table('payment_methods')->insert($param);
     }

--- a/resources/js/Components/StripeCheckoutButton.vue
+++ b/resources/js/Components/StripeCheckoutButton.vue
@@ -7,6 +7,7 @@ import { loadStripe } from '@stripe/stripe-js'
 
 const props = defineProps({
     itemId: Number,
+    paymentMethodId: Number,
 });
 
 onUnmounted(() => {
@@ -22,7 +23,9 @@ async function submit() {
     const stripe = await loadStripe(stripeKey);
 
     await axios
-        .post('/api/purchase/' + props.itemId)
+        .post('/api/purchase/' + props.itemId, {
+            paymentMethodId: props.paymentMethodId,
+        })
         .then(async (res) => {
             open.value = true;
 
@@ -79,5 +82,6 @@ async function hide() {
                 </div>
             </div>
         </Teleport>
+
     </div>
 </template>

--- a/resources/js/Pages/Purchase.vue
+++ b/resources/js/Pages/Purchase.vue
@@ -12,12 +12,6 @@ const props = defineProps({
 
 const open = ref(false);
 const selectedId = ref(1);
-const paymentMethodList = {
-    1: "クレジットカード決済",
-    2: "コンビニ払い",
-    3: "銀行振込",
-};
-
 </script>
 
 <template>

--- a/resources/js/Pages/Purchase.vue
+++ b/resources/js/Pages/Purchase.vue
@@ -1,12 +1,23 @@
 <script setup>
 import { Head, Link } from '@inertiajs/vue3';
+import { ref } from 'vue'
 import ItemImage from "@/Components/ItemImage.vue";
 import StripeCheckoutButton from "@/Components/StripeCheckoutButton.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 
 const props = defineProps({
     item: Object,
+    paymentMethods: Object,
 });
+
+const open = ref(false);
+const selectedId = ref(1);
+const paymentMethodList = {
+    1: "クレジットカード決済",
+    2: "コンビニ払い",
+    3: "銀行振込",
+};
+
 </script>
 
 <template>
@@ -29,7 +40,7 @@ const props = defineProps({
                 </div>
                 <div class="flex justify-between mt-2">
                     <span class="font-bold text-lg">支払い方法</span>
-                    <button class="text-[#2085D2]">変更する</button>
+                    <button class="text-[#2085D2]" @click="open = true">変更する</button>
                 </div>
                 <div class="flex justify-between mt-44">
                     <span class="font-bold text-lg">配送先</span>
@@ -42,29 +53,49 @@ const props = defineProps({
                     <table class="w-full text-left">
                         <tbody>
                             <tr>
-                                <th class="w-3/5 font-normal py-4">商品代金</th>
+                                <th class="w-1/2 font-normal py-4">商品代金</th>
                                 <td>{{ item.price }}</td>
                             </tr>
                             <tr>
-                                <th class="w-3/5 font-normal py-4"><br></th>
+                                <th class="w-1/2 font-normal py-4"><br></th>
                                 <td></td>
                             </tr>
                             <tr>
-                                <th class="w-3/5 font-normal py-4">支払い金額</th>
+                                <th class="w-1/2 font-normal py-4">支払い金額</th>
                                 <td>{{ item.price }}</td>
                             </tr>
                             <tr>
-                                <th class="w-3/5 font-normal py-4">支払い方法</th>
-                                <td>コンビニ払い</td>
+                                <th class="w-1/2 font-normal py-4">支払い方法</th>
+                                <td>{{ paymentMethods[selectedId] }}</td>
                             </tr>
                         </tbody>
                     </table>
                 </div>
                 <div class="mt-14">
-                    <PrimaryButton v-if="item.is_sold === true" disabled>SOLD OUT</PrimaryButton>
-                    <StripeCheckoutButton v-else :itemId="item.id">購入する</StripeCheckoutButton>
+                    <PrimaryButton v-if="item.is_sold === true" disabled>
+                        SOLD OUT
+                    </PrimaryButton>
+                    <StripeCheckoutButton v-else :itemId="item.id" :paymentMethodId="selectedId">
+                        購入する
+                    </StripeCheckoutButton>
                 </div>
             </div>
         </div>
+        <!-- 支払い方法変更モーダル -->
+        <Teleport to="body">
+            <div
+                v-if="open"
+                class="fixed top-0 right-0 bottom-0 left-0 bg-[rgba(0,0,0,.3)]"
+            >
+                <div class="fixed top-1/2 left-1/2 z-50 bg-white translate-y-[-50%] translate-x-[-50%] drop-shadow-xl py-10 px-20 max-h-[85vh] overflow-auto">
+                    <div v-for="(name, id) in paymentMethods" :key="id" class="flex items-center mb-2">
+                        <input type="radio" v-model="selectedId" :value="id" :id="name">
+                        <label :for="name" class="ml-2 font-bold">{{ name }}</label>
+                    </div>
+
+                    <button @click="open = false" class="block w-3/4 mx-auto mt-10">Close</button>
+                </div>
+            </div>
+        </Teleport>
     </div>
 </template>


### PR DESCRIPTION
## 【概要】
購入ページで支払い方法を選択可能にし、それに応じて決済方法が切り替わるように対応

## 【実装内容詳細】
- payment_methodsテーブルのカラムを変更し、関連Seederを調整
	- 追加：payment_method_type
- 購入ページ表示時にpayment_methodsテーブルから取得した「支払い方法一覧」をパラメータとして渡すよう調整
- 以下処理を追加&調整
	- 購入ページ：支払い方法の「変更する」押下時に選択モーダルを表示
	- 購入ボタンコンポーネント：選択された支払い方法をcheckout session作成APIに渡す
	- checkout session作成API：ユーザー選択（カードorコンビニ払いor銀行振込）に応じたセッションを作成