### PR TITLE
コメントページの商品イメージが表示されなくなっている問題を修正

### DIFF
--- a/resources/js/Pages/Comment.vue
+++ b/resources/js/Pages/Comment.vue
@@ -32,7 +32,7 @@ function submit() {
         <div class="flex w-full">
             <!-- 商品画像(左側) -->
             <div class="w-1/2 p-20">
-                <ItemImage :path="item.image_url" />
+                <ItemImage :item="item" />
             </div>
             <!-- 詳細情報(右側) -->
             <div class="w-1/2 p-20">


### PR DESCRIPTION
- ItemImageコンポーネントのPropsを「画像のURL」から「商品情報オブジェクト」に変更した際、コメントページへの対応が漏れていた事により商品画像が表示出来なくっていた為、その修正対応を実施