### PR TITLE
Feature/sell item

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
+use App\Models\Category;
+use App\Models\Condition;
+
+class SellController extends Controller
+{
+    public function create() {
+        return Inertia::render('Sell', [
+            'categories' => Category::all()->pluck('name', 'id'),
+            'conditions' => Condition::all()->pluck('name', 'id'),
+        ]);
+    }
+
+    public function store(Request $request) {
+        // 商品登録処理
+        dd($request);
+    }
+}

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -11,6 +11,7 @@ use App\Models\Category;
 use App\Models\Condition;
 use App\Models\Item;
 use Stripe\StripeClient;
+use App\Http\Requests\ItemRegisterRequest;
 
 class SellController extends Controller
 {
@@ -21,7 +22,7 @@ class SellController extends Controller
         ]);
     }
 
-    public function store(Request $request) {
+    public function store(ItemRegisterRequest $request) {
         $user = $request->user();
 
         try {
@@ -55,7 +56,7 @@ class SellController extends Controller
             $image_path = str_replace("img", "/storage/img", $image_path);
 
             // 商品登録処理
-            Item::create([
+            $item = Item::create([
                 'name' => $request->name,
                 'brand' => $request->brand,
                 'price' => $request->price,
@@ -65,6 +66,9 @@ class SellController extends Controller
                 'user_id' => $user->id,
                 'stripe_price_id' => $price->id,
             ]);
+
+            // カテゴリー登録処理
+            $item->categories()->attach($request->categories);
 
             DB::commit();
         } catch (\Exception $e) {

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -38,7 +38,7 @@ class SellController extends Controller
                 ]);
 
                 $user->update([
-                    'stripe_customer_id' => null,
+                    'stripe_customer_id' => $customer->id,
                 ]);
             }
 

--- a/app/Http/Requests/ItemRegisterRequest.php
+++ b/app/Http/Requests/ItemRegisterRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class ItemRegisterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'image' => [
+                'required',
+                'file',
+                'image',
+                'mimes:jpeg,jpg,png,bmp',
+                'extensions:jpeg,jpg,png,bmp',
+                'max:10240'
+            ],
+            'categories' => ['required'],
+            'condition_id' => ['required'],
+            'name' => ['required', 'string', 'max:100'],
+            'brand' => ['nullable', 'string', 'max:50'],
+            'description' => ['required', 'string', 'max:1000'],
+            'price' => ['required', 'numeric', 'integer', 'min:300'],
+        ];
+    }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator) {
+                // 「商品の状態」未選択エラー
+                if ($this->input('condition_id') < 1) {
+                    $validator->errors()->add(
+                        'condition_id',
+                        '商品の状態を選択してください'
+                    );
+                }
+            }
+        ];
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -29,23 +29,23 @@ class Item extends Model
         return $this->belongsToMany('App\Models\User', 'sold_items');
     }
 
-    public function soldItems (): HasMany {
+    public function soldItems(): HasMany {
         return $this->hasMany('App\Models\SoldItem');
     }
 
-    public function categories (): BelongsToMany {
+    public function categories(): BelongsToMany {
         return $this->belongsToMany('App\Models\Category');
     }
 
-    public function condition (): BelongsTo {
+    public function condition(): BelongsTo {
         return $this->belongsTo('App\Models\Condition');
     }
 
-    public function comments (): HasMany {
+    public function comments(): HasMany {
         return $this->hasMany('App\Models\Comment');
     }
 
-    public function commentUsers (): BelongsToMany {
+    public function commentUsers(): BelongsToMany {
         return $this->belongsToMany('App\Models\User', 'comments');
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'stripe_customer_id'
     ];
 
     /**

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('stripe_customer_id')->nullable()->unique();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2024_12_18_150442_create_items_table.php
+++ b/database/migrations/2024_12_18_150442_create_items_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->string('image_url');
             $table->foreignId('condition_id')->constrained();
             $table->foreignId('user_id')->constrained();
+            $table->string('stripe_price_id');
             $table->timestamp('created_at')->useCurrent()->nullable();
             $table->timestamp('updated_at')->useCurrent()->nullable();
         });

--- a/database/migrations/2024_12_18_150442_create_items_table.php
+++ b/database/migrations/2024_12_18_150442_create_items_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('brand')->nullable();
             $table->integer('price');
-            $table->string('description');
+            $table->string('description', 1000);
             $table->string('image_url');
             $table->foreignId('condition_id')->constrained();
             $table->foreignId('user_id')->constrained();

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -24,6 +24,7 @@ class ItemSeeder extends Seeder
                 'image_url' => '/img/dummy_item.png',
                 'condition_id' => fake()->numberBetween(1, $condition_num),
                 'user_id' => '1',
+                'stripe_price_id' => 'price_1QdnKOBli9nlS8GV5hoD5foG',
             ];
             DB::table('items')->insert($param);
         }

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -176,6 +176,10 @@ return [
         'postcode' => [
             'regex' => '使用できない文字が含まれています（使用可能文字：数字のみ）',
         ],
+        'price' => [
+            'min' => '300円以上の価格を設定してください',
+        ],
+
     ],
 
     /*
@@ -197,7 +201,9 @@ return [
         'available' => '利用可能',
         'birthday' => '誕生日',
         'body' => '本文',
+        'brand' => 'ブランド',
         'building' => '建物名',
+        'categories' => 'カテゴリー',
         'city' => '市',
         'content' => 'コンテンツ',
         'country' => '国',

--- a/resources/js/Components/CheckboxInput.vue
+++ b/resources/js/Components/CheckboxInput.vue
@@ -1,0 +1,21 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+
+const model = defineModel({
+    type: Array,
+    required: true,
+});
+
+const props = defineProps({
+    options: Object,
+});
+</script>
+
+<template>
+    <div class="flex flex-wrap gap-x-6 p-4 border rounded border-gray-600 shadow-sm">
+        <div v-for="(name, id) in options" :key="id" class="flex items-center gap-1">
+            <input type="checkbox" :id="name" :value="id" v-model="model">
+            <label :for="name">{{ name }}</label>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/ItemImage.vue
+++ b/resources/js/Components/ItemImage.vue
@@ -9,7 +9,7 @@ const props = defineProps({
         <img
             :src="item.image_url"
             alt="商品画像"
-            class="w-full bg-gray-200 border border-gray-400 aspect-[3/4] object-contain"
+            class="w-full bg-gray-800 border border-gray-400 aspect-[3/4] object-contain"
         >
         <!-- SOLD OUTアイコン -->
         <div v-if="item.is_sold" class="w-2/5 absolute top-0 left-0">

--- a/resources/js/Components/PriceInput.vue
+++ b/resources/js/Components/PriceInput.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+
+const model = defineModel({
+    type: Number,
+    required: true,
+});
+
+const input = ref(null);
+
+onMounted(() => {
+    if (input.value.hasAttribute('autofocus')) {
+        input.value.focus();
+    }
+});
+
+defineExpose({ focus: () => input.value.focus() });
+</script>
+
+<template>
+    <div class="relative">
+        <input
+            type="number"
+            class="w-full pl-8 rounded border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            v-model="model"
+            ref="input"
+        />
+        <span class="absolute top-1/2 left-3 bg-white translate-y-[-50%]">￥</span>
+    </div>
+</template>

--- a/resources/js/Components/SectionTitle.vue
+++ b/resources/js/Components/SectionTitle.vue
@@ -1,0 +1,7 @@
+<template>
+    <div class="mt-10">
+        <h3 class="text-xl font-bold text-gray-500 border-b border-gray-500">
+            <slot />
+        </h3>
+    </div>
+</template>

--- a/resources/js/Components/SelectInput.vue
+++ b/resources/js/Components/SelectInput.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+
+const model = defineModel({
+    type: Number,
+    required: true,
+});
+
+const props = defineProps({
+    options: Object,
+});
+</script>
+
+<template>
+    <select v-model="model" class="w-full rounded">
+        <option v-for="(name, id) in options" :key="id" :value="id">
+            {{ name }}
+        </option>
+    </select>
+</template>

--- a/resources/js/Layouts/DefaultLayout.vue
+++ b/resources/js/Layouts/DefaultLayout.vue
@@ -30,7 +30,7 @@ const isLogined = (usePage().props.auth.user !== null);
                             <NavLink v-if="!isLogined" :href="route('login')">ログイン</NavLink>
                             <NavLink v-if="!isLogined" :href="route('register')">会員登録</NavLink>
                             <!-- 全ユーザー共通 -->
-                            <Link :href="route('login')" as="button" type="button" class="py-1 px-4 bg-white text-black text-sm font-bold rounded">出品</Link>
+                            <Link :href="route('sell')" as="button" type="button" class="py-1 px-4 bg-white text-black text-sm font-bold rounded">出品</Link>
                         </nav>
                     </div>
                 </div>

--- a/resources/js/Pages/Sell.vue
+++ b/resources/js/Pages/Sell.vue
@@ -28,12 +28,13 @@ const form = useForm({
 const previewUrl = ref('');
 
 function submit() {
-    form
-    // .transform((data) => {
-    //     console.log(data);
-    // })
-    .post(route('sell'));
+    form.post(route('sell'));
 };
+
+function imageReset() {
+    form.image = null;
+    previewUrl.value = null;
+}
 </script>
 
 <template>
@@ -43,12 +44,18 @@ function submit() {
         <form @submit.prevent="submit" enctype="multipart/form-data">
             <div class="max-w-2xl">
                 <InputLabel>商品画像</InputLabel>
-                <img v-if="previewUrl" :src="previewUrl" alt="no image" class="w-full">
+                <div v-if="previewUrl">
+                    <img :src="previewUrl" alt="no image" class="w-full">
+                    <button @click="imageReset()" class="w-full text-center rounded-md border border-red-500 bg-white mt-2 px-8 font-bold tracking-widest text-red-500 shadow-sm transition duration-150 ease-in-out hover:bg-red-500 hover:text-white disabled:opacity-25">
+                        画像をリセットする
+                    </button>
+                </div>
                 <div v-else class="w-full h-40 border border-black border-dashed flex justify-center items-center">
                     <ImageInput v-model:previewUrl="previewUrl" v-model:file="form.image">
                         画像を選択する
                     </ImageInput>
                 </div>
+                <InputError class="mt-2" :message="form.errors.image" />
             </div>
             <SectionTitle>商品の詳細</SectionTitle>
             <div class="pt-6">
@@ -71,7 +78,6 @@ function submit() {
                 <InputError class="mt-2" :message="form.errors.condition_id" />
             </div>
             <SectionTitle>商品名と説明</SectionTitle>
-            <InputError class="mt-2" :message="form.errors.image" />
             <div class="pt-6">
                 <InputLabel>商品名</InputLabel>
                 <TextInput v-model="form.name" required />

--- a/resources/js/Pages/Sell.vue
+++ b/resources/js/Pages/Sell.vue
@@ -5,6 +5,7 @@ import InputError from '@/Components/InputError.vue';
 import TextInput from "@/Components/TextInput.vue";
 import TextAreaInput from "@/Components/TextAreaInput.vue";
 import PriceInput from "@/Components/PriceInput.vue";
+import SelectInput from "@/Components/SelectInput.vue";
 import InputLabel from "@/Components/InputLabel.vue";
 import ImageInput from "@/Components/ImageInput.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
@@ -71,11 +72,7 @@ function imageReset() {
             </div>
             <div class="pt-6">
                 <InputLabel>商品の状態</InputLabel>
-                <select v-model="form.condition_id" class="w-full rounded">
-                    <option v-for="(name, id) in conditions" :key="id" :value="id">
-                        {{ name }}
-                    </option>
-                </select>
+                <SelectInput :options="conditions" v-model="form.condition_id" />
                 <InputError class="mt-2" :message="form.errors.condition_id" />
             </div>
             <SectionTitle>商品名と説明</SectionTitle>

--- a/resources/js/Pages/Sell.vue
+++ b/resources/js/Pages/Sell.vue
@@ -6,6 +6,7 @@ import TextInput from "@/Components/TextInput.vue";
 import TextAreaInput from "@/Components/TextAreaInput.vue";
 import PriceInput from "@/Components/PriceInput.vue";
 import SelectInput from "@/Components/SelectInput.vue";
+import CheckboxInput from "@/Components/CheckboxInput.vue";
 import InputLabel from "@/Components/InputLabel.vue";
 import ImageInput from "@/Components/ImageInput.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
@@ -62,12 +63,7 @@ function imageReset() {
             <SectionTitle>商品の詳細</SectionTitle>
             <div class="pt-6">
                 <InputLabel>カテゴリー</InputLabel>
-                <div class="flex flex-wrap gap-x-6 p-4 border rounded border-gray-600 shadow-sm">
-                    <div v-for="(name, id) in categories" :key="id" class="flex items-center gap-1">
-                        <input type="checkbox" :id="name" :value="id" v-model="form.categories">
-                        <label :for="name">{{ name }}</label>
-                    </div>
-                </div>
+                <CheckboxInput :options="categories" v-model="form.categories" />
                 <InputError class="mt-2" :message="form.errors.categories" />
             </div>
             <div class="pt-6">

--- a/resources/js/Pages/Sell.vue
+++ b/resources/js/Pages/Sell.vue
@@ -4,6 +4,7 @@ import { Head, useForm } from '@inertiajs/vue3';
 import InputError from '@/Components/InputError.vue';
 import TextInput from "@/Components/TextInput.vue";
 import TextAreaInput from "@/Components/TextAreaInput.vue";
+import PriceInput from "@/Components/PriceInput.vue";
 import InputLabel from "@/Components/InputLabel.vue";
 import ImageInput from "@/Components/ImageInput.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
@@ -19,7 +20,7 @@ const form = useForm({
     image: null,
     name: '',
     brand: '',
-    price: 0,
+    price: null,
     description: '',
     condition_id: 0,
     categories: [],
@@ -96,7 +97,7 @@ function imageReset() {
             <SectionTitle>販売価格</SectionTitle>
             <div class="pt-6">
                 <InputLabel>販売価格</InputLabel>
-                <TextInput type="number" v-model="form.price" required />
+                <PriceInput v-model="form.price" required />
                 <InputError class="mt-2" :message="form.errors.price" />
             </div>
             <div class="pt-16">

--- a/resources/js/Pages/Sell.vue
+++ b/resources/js/Pages/Sell.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref } from 'vue'
+import { Head, useForm } from '@inertiajs/vue3';
+import InputError from '@/Components/InputError.vue';
+import TextInput from "@/Components/TextInput.vue";
+import TextAreaInput from "@/Components/TextAreaInput.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import ImageInput from "@/Components/ImageInput.vue";
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import PageTitle from "@/Components/PageTitle.vue"
+import SectionTitle from "@/Components/SectionTitle.vue";
+
+const props = defineProps({
+    categories: Object,
+    conditions: Object,
+});
+
+const form = useForm({
+    image: null,
+    name: '',
+    brand: '',
+    price: 0,
+    description: '',
+    condition_id: 0,
+    categories: [],
+});
+
+const previewUrl = ref('');
+
+function submit() {
+    form
+    // .transform((data) => {
+    //     console.log(data);
+    // })
+    .post(route('sell'));
+};
+</script>
+
+<template>
+    <div class="max-w-xl mx-auto mb-20">
+        <Head title="出品ページ" />
+        <PageTitle>商品の出品</PageTitle>
+        <form @submit.prevent="submit" enctype="multipart/form-data">
+            <div class="max-w-2xl">
+                <InputLabel>商品画像</InputLabel>
+                <img v-if="previewUrl" :src="previewUrl" alt="no image" class="w-full">
+                <div v-else class="w-full h-40 border border-black border-dashed flex justify-center items-center">
+                    <ImageInput v-model:previewUrl="previewUrl" v-model:file="form.image">
+                        画像を選択する
+                    </ImageInput>
+                </div>
+            </div>
+            <SectionTitle>商品の詳細</SectionTitle>
+            <div class="pt-6">
+                <InputLabel>カテゴリー</InputLabel>
+                <div class="flex flex-wrap gap-x-6 p-4 border rounded border-gray-600 shadow-sm">
+                    <div v-for="(name, id) in categories" :key="id" class="flex items-center gap-1">
+                        <input type="checkbox" :id="name" :value="id" v-model="form.categories">
+                        <label :for="name">{{ name }}</label>
+                    </div>
+                </div>
+                <InputError class="mt-2" :message="form.errors.categories" />
+            </div>
+            <div class="pt-6">
+                <InputLabel>商品の状態</InputLabel>
+                <select v-model="form.condition_id" class="w-full rounded">
+                    <option v-for="(name, id) in conditions" :key="id" :value="id">
+                        {{ name }}
+                    </option>
+                </select>
+                <InputError class="mt-2" :message="form.errors.condition_id" />
+            </div>
+            <SectionTitle>商品名と説明</SectionTitle>
+            <InputError class="mt-2" :message="form.errors.image" />
+            <div class="pt-6">
+                <InputLabel>商品名</InputLabel>
+                <TextInput v-model="form.name" required />
+                <InputError class="mt-2" :message="form.errors.name" />
+            </div>
+            <div class="pt-6">
+                <InputLabel>ブランド</InputLabel>
+                <TextInput v-model="form.brand" />
+                <InputError class="mt-2" :message="form.errors.brand" />
+            </div>
+            <div class="pt-6">
+                <InputLabel>商品の説明</InputLabel>
+                <TextAreaInput v-model="form.description" required />
+                <InputError class="mt-2" :message="form.errors.description" />
+            </div>
+            <SectionTitle>販売価格</SectionTitle>
+            <div class="pt-6">
+                <InputLabel>販売価格</InputLabel>
+                <TextInput type="number" v-model="form.price" required />
+                <InputError class="mt-2" :message="form.errors.price" />
+            </div>
+            <div class="pt-16">
+                <PrimaryButton>出品する</PrimaryButton><br>
+            </div>
+        </form>
+    </div>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\CommentController;
 use App\Http\Controllers\Api\CheckoutSessionController;
 use App\Http\Controllers\PurchaseController;
 use App\Http\Controllers\ShipAddressController;
+use App\Http\Controllers\SellController;
 
 // Route::get('/', function () {
 //     return Inertia::render('Welcome', [
@@ -25,9 +26,7 @@ use App\Http\Controllers\ShipAddressController;
 Route::get('/', [TopPageController::class, 'index'])->name('top');
 Route::get('/item/{item_id}', [ItemDetailController::class, 'show'])->name('item.detail');
 
-// Route::get('/test', function () {
-//     return Inertia::render('Test');
-// });
+// Route::get('/test', function () { return Inertia::render('Test'); });
 
 Route::middleware('auth')->group(function () {
     // Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
@@ -48,6 +47,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/purchase/{item_id}', [PurchaseController::class, 'create'])->name('purchase');
     Route::get('/purchase/address/{item_id}', [ShipAddressController::class, 'edit'])->name('purchase.address');
     Route::post('/purchase/address/{item_id}', [ShipAddressController::class, 'update']);
+    Route::get('/sell', [SellController::class, 'create'])->name('sell');
+    Route::post('/sell', [SellController::class, 'store']);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 【概要】
商品の出品処理を実装

## 【実装内容詳細】
- 出品ページ用vueファイル作成
	- Sell.vue
- 以下コンポーネントを作成
	- PriceInput.vue（価格入力ボックス）
	- SelectInput.vue（セレクトボックス入力欄）
	- CheckboxInput.vue（チェックボックス入力欄）
- 以下ルーティングとそれに対応するコントローラーメソッドの追加
	- 出品ページ表示（SellController::class, 'create'）
	- 出品処理（SellController::class, 'store'）
- バリデーション実装
	- 商品作成用のリクエストフォーム作成（ItemRegisterRequest）
	- バリデーションメッセージを一部調整
- checkout session作成APIに以下調整を追加
	- 出品時に作成されたStripe価格IDを参照してセッション作成するよう処理を追加
	- usersテーブルの stripe_customer_id を参照してセッション作成するよう処理を追加
	- stripe_customer_id が未作成の場合、新規作成する処理を追加