### PR TITLE
Feature/admin mail

### DIFF
--- a/app/Http/Controllers/Admin/AdminMailController.php
+++ b/app/Http/Controllers/Admin/AdminMailController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AdminMailController extends Controller
+{
+    public function create() {
+        return inertia::render('Admin/AdminMail');
+    }
+}

--- a/app/Http/Controllers/Admin/AdminMailController.php
+++ b/app/Http/Controllers/Admin/AdminMailController.php
@@ -7,10 +7,38 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
+use App\Models\User;
+use App\Jobs\SendAdminMail;
+use Illuminate\Support\Facades\Bus;
 
 class AdminMailController extends Controller
 {
     public function create() {
         return inertia::render('Admin/AdminMail');
+    }
+
+    public function sendMail(Request $request) {
+        try {
+            // 送信対象は全ユーザー  ※管理者（role_id:1）のみ除外
+            $users = User::where('role_id', '>=', 2)->get();
+
+            // 全ユーザー分のメール送信ジョブを作成してディスパッチ
+            $jobs = $users->map(function ($user) use ($request) {
+                return new SendAdminMail($user, $request->subject, $request->mainText);
+            });
+            $batch = Bus::batch($jobs)->dispatch();
+
+            $status = 'success';
+            $message = 'メール送信しました';
+        } catch (\Exception $e) {
+            $status = 'error';
+            $message = 'メール送信に失敗しました';
+            Log::error($e);
+        }
+
+        return to_route('admin.mail')->with([
+            'status' => $status,
+            'message' => $message,
+        ]);
     }
 }

--- a/app/Jobs/SendAdminMail.php
+++ b/app/Jobs/SendAdminMail.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\AdminMail;
+
+/**
+ * 管理者から利用者へ「お知らせメール」送信用のJobクラス
+ *
+ * @var mixed $user メール送信対象ユーザー
+ * @var mixed $subject メール題名
+ * @var mixed $main_text メール本文
+ */
+class SendAdminMail implements ShouldQueue
+{
+    use Queueable, Batchable, Dispatchable;
+
+    private $user;
+    private $subject;
+    private $main_text;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct($user, $subject, $main_text)
+    {
+        $this->user = $user;
+        $this->subject = $subject;
+        $this->main_text = $main_text;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        Log::info('お知らせメール送信:'.$this->user->email);
+        Mail::to($this->user->email)->send(new AdminMail(
+            $this->user->name,
+            $this->subject,
+            $this->main_text,
+        ));
+    }
+}

--- a/app/Mail/AdminMail.php
+++ b/app/Mail/AdminMail.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * 管理者から利用者へ「お知らせメール」送信用のMailクラス
+ *
+ * @var mixed $subject メール題名
+ * @var mixed $main_text メール本文
+ * @var mixed $name メール送信対象ユーザーの名前
+ */
+class AdminMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $subject;
+    protected $main_text;
+    protected $name;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct($name, $subject, $main_text)
+    {
+        $this->name = $name;
+        $this->subject = $subject;
+        $this->main_text = $main_text;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: $this->subject,
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.admin_mail',
+            with: [
+                'main_text' => $this->main_text,
+                'name' => $this->name,
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/resources/js/Pages/Admin/AdminMail.vue
+++ b/resources/js/Pages/Admin/AdminMail.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { Head, router, useForm, usePage } from '@inertiajs/vue3';
+import { reactive, ref, computed } from 'vue'
+import AdminLayout from "@/Layouts/AdminLayout.vue";
+import PageTitle from "@/Components/PageTitle.vue"
+import TextInput from "@/Components/TextInput.vue";
+import TextAreaInput from "@/Components/TextAreaInput.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import InputError from '@/Components/InputError.vue';
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import FlashMassageModal from "@/Components/FlashMassageModal.vue";
+
+defineOptions({ layout: AdminLayout })
+
+defineProps({
+    users: Object,
+})
+
+const form = useForm({
+    subject: null,
+    mainText: null,
+});
+
+function submit() {
+    form.post(route('admin.mail'));
+};
+
+const showFlashMessage = ref(false);
+const message = computed(() => usePage().props.flash.message);
+const status = computed(() => usePage().props.flash.status);
+</script>
+
+<template>
+    <div class="max-w-3xl mx-auto p-5 pb-20 h-full">
+        <Head title="Adminメール送信ページ" />
+
+        <!-- メール作成フォーム -->
+        <form @submit.prevent="submit" class="h-full flex flex-col">
+            <PageTitle>Adminメール送信</PageTitle>
+
+            <div>
+                <InputLabel>件名</InputLabel>
+                <TextInput v-model="form.subject" rows="10" required />
+                <InputError class="mt-2" :message="form.errors.subject" />
+            </div>
+            <div class="pt-6 grow flex flex-col">
+                <InputLabel>本文</InputLabel>
+                <TextAreaInput v-model="form.mainText" class="grow" required />
+                <InputError class="mt-2" :message="form.errors.mainText" />
+            </div>
+            <div class="pt-6">
+                <PrimaryButton>送信する</PrimaryButton><br>
+            </div>
+        </form>
+
+        <!-- フラッシュメッセージモーダル -->
+        <FlashMassageModal v-model:status="status" v-model:show="showFlashMessage">
+            {{ message }}
+        </FlashMassageModal>
+
+    </div>
+</template>

--- a/resources/js/Pages/Admin/AdminMail.vue
+++ b/resources/js/Pages/Admin/AdminMail.vue
@@ -21,13 +21,14 @@ const form = useForm({
     mainText: null,
 });
 
-function submit() {
-    form.post(route('admin.mail'));
-};
-
 const showFlashMessage = ref(false);
 const message = computed(() => usePage().props.flash.message);
 const status = computed(() => usePage().props.flash.status);
+
+function submit() {
+    form.post(route('admin.mail'));
+    showFlashMessage.value = true;
+};
 </script>
 
 <template>
@@ -43,12 +44,17 @@ const status = computed(() => usePage().props.flash.status);
                 <TextInput v-model="form.subject" rows="10" required />
                 <InputError class="mt-2" :message="form.errors.subject" />
             </div>
-            <div class="pt-6 grow flex flex-col">
+            <div class="mt-6 grow flex flex-col">
                 <InputLabel>本文</InputLabel>
+                <p class="my-2 text-lg">○○様</p>
                 <TextAreaInput v-model="form.mainText" class="grow" required />
                 <InputError class="mt-2" :message="form.errors.mainText" />
+                <div class="my-2">
+                    <p>※本メールは送信専用です</p>
+                    <p class="pt-1 border-t border-black">配信元&nbsp;:&nbsp;COACHTECHフリーマーケット</p>
+                </div>
             </div>
-            <div class="pt-6">
+            <div class="pt-8">
                 <PrimaryButton>送信する</PrimaryButton><br>
             </div>
         </form>

--- a/resources/views/emails/admin_mail.blade.php
+++ b/resources/views/emails/admin_mail.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>お知らせメール</title>
+</head>
+
+<body>
+    <table width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td>
+                <p style="font-size: 18px; font-weight: bold;">{{ $name }}&nbsp;様</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>{!! nl2br(e( $main_text )) !!}</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>
+                ※本メールは送信専用です<br>
+                ------------------------------------------------------------------------------------------------------------<br>
+                配信元&nbsp;:&nbsp;COACHTECHフリーマーケット
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,7 @@ Route::middleware('auth', 'admin')->group(function () {
     Route::get('/admin/comment', [AdminCommentController::class, 'index'])->name('admin.comment');
     Route::post('/admin/comment', [AdminCommentController::class, 'destroy']);
     Route::get('/admin/mail', [AdminMailController::class, 'create'])->name('admin.mail');
+    Route::post('/admin/mail', [AdminMailController::class, 'sendMail']);
 });
 
 require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\ShipAddressController;
 use App\Http\Controllers\SellController;
 use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Admin\AdminCommentController;
+use App\Http\Controllers\Admin\AdminMailController;
 
 // Route::get('/', function () {
 //     return Inertia::render('Welcome', [
@@ -60,6 +61,7 @@ Route::middleware('auth', 'admin')->group(function () {
     Route::post('/admin/user', [AdminUserController::class, 'destroy']);
     Route::get('/admin/comment', [AdminCommentController::class, 'index'])->name('admin.comment');
     Route::post('/admin/comment', [AdminCommentController::class, 'destroy']);
+    Route::get('/admin/mail', [AdminMailController::class, 'create'])->name('admin.mail');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## 【概要】
管理画面でのAdminメール作成ページ表示とメール送信機能を実装

## 【実装内容詳細】
- Adminメール作成ページ用vueファイル作成
	- AdminMail.vue
- 以下ルーティングとそれに対応するコントローラーメソッドの追加
	- メール作成ページ表示（AdminMailController::class, 'create'）
	- メール送信（AdminMailController::class, 'sendMail'）
- メール本文のbladeファイル追加
	- admin_mail.blade.php
- Mailクラス追加
	- AdminMail.php
- Jobクラス追加
	- SendAdminMail.php