### PR TITLE
MyPageLayout.vue にてユーザーの名前、画像を参照して表示するよう修正

### DIFF
--- a/app/Http/Controllers/MyPageController.php
+++ b/app/Http/Controllers/MyPageController.php
@@ -12,9 +12,16 @@ use App\Services\ItemService;
 class MyPageController extends Controller
 {
     public function index(Request $request) {
-        // 出品済み商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
+        // 商品一覧の取得処理
         $item_service = new ItemService;
-        $items = $item_service->getSellItemsWithLike();
+
+        if ($request->filter === 'purchased') {
+            // 購入済み商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
+            $items = $item_service->getPurchasedItemsWithLike();
+        } else {
+            // 出品済み商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
+            $items = $item_service->getSellItemsWithLike();
+        }
 
         // ページネーション
         $items = new LengthAwarePaginator
@@ -23,32 +30,22 @@ class MyPageController extends Controller
             $items->count(),
             20,
             $request->page,
-            ['path' => $request->url()]
+            [
+                'path' => request()->url() .
+                (
+                    request()->except('page')
+                    ? '?' .  http_build_query(request()->except('page'))
+                    : ''
+                )
+            ]
         );
 
         return Inertia::render('MyPage', [
-            'items' => $items
+            'items' => $items,
+            'user' => [
+                'name' => $request->user()->name,
+                'image_url' => $request->user()->profile->image_url,
+            ],
         ]);
     }
-
-    public function showPurchased(Request $request) {
-        // 購入済み商品を取得（お気に入り商品かどうかの「is_like」フラグ付き）
-        $item_service = new ItemService;
-        $items = $item_service->getPurchasedItemsWithLike();
-
-        // ページネーション
-        $items = new LengthAwarePaginator
-        (
-            $items->forPage($request->page, 20),
-            $items->count(),
-            20,
-            $request->page,
-            ['path' => $request->url()]
-        );
-
-        return Inertia::render('MyPage', [
-            'items' => $items
-        ]);
-    }
-
 }

--- a/resources/js/Layouts/MyPageLayout.vue
+++ b/resources/js/Layouts/MyPageLayout.vue
@@ -1,22 +1,35 @@
 <script setup>
 import { ref } from 'vue';
-import { Link } from '@inertiajs/vue3';
+import { Link, router } from '@inertiajs/vue3';
 import NavLink from '@/Components/NavLink.vue';
 import SecondaryButton from "../Components/SecondaryButton.vue";
 import UserIcon from "../Components/UserIcon.vue";
 import DefaultLayout from "@/Layouts/DefaultLayout.vue";
+
+defineProps({
+    user: Object,
+})
+
+function showItems(filter) {
+    router.reload({
+        data: {
+            filter: filter,
+            page: 1,
+        },
+        only: ['items'],
+    });
+}
 </script>
 
 <template>
-    <DefaultLayout>
     <div class="pt-10 pb-2 px-6 md:px-20 border-b border-gray-600">
         <div class="max-w-7xl mx-auto">
             <div class="flex justify-around items-center mb-10 max-sm:flex-col">
                 <div class="flex gap-10 items-center max-sm:w-full">
                     <div class="w-24 md:w-32">
-                        <UserIcon path="/img/default_user_icon.png" />
+                        <UserIcon :path="user.image_url" />
                     </div>
-                    <span class="font-bold text-2xl">ユーザー名</span>
+                    <span class="font-bold text-2xl">{{ user.name }}</span>
                 </div>
                 <div class="max-sm:mt-5 max-sm:w-full">
                     <Link href="/mypage/profile">
@@ -25,15 +38,14 @@ import DefaultLayout from "@/Layouts/DefaultLayout.vue";
                 </div>
             </div>
             <ul class="flex gap-10 md:gap-20">
-                <li :class="{ 'text-red-500' : $page.url === '/mypage' }">
-                    <Link href="/mypage" class="font-bold">出品した商品</Link>
+                <li :class="{ 'text-red-500' : route().params.filter === 'sell' || route().params.filter === undefine }">
+                    <button @click="showItems('sell')" class="font-bold">出品した商品</button>
                 </li>
-                <li :class="{ 'text-red-500' : $page.url === '/mypage/purchased' }">
-                    <Link href="/mypage/purchased" class="font-bold">購入した商品</Link>
+                <li :class="{ 'text-red-500' : route().params.filter === 'purchased' }">
+                    <button @click="showItems('purchased')" class="font-bold">購入した商品</button>
                 </li>
             </ul>
         </div>
     </div>
     <slot />
-    </DefaultLayout>
 </template>

--- a/resources/js/Pages/MyPage.vue
+++ b/resources/js/Pages/MyPage.vue
@@ -1,25 +1,26 @@
 <script setup>
-import MyPageLayoutVue from '@/Layouts/MyPageLayout.vue';
+import MyPageLayout from '@/Layouts/MyPageLayout.vue';
 import { Head, Link } from '@inertiajs/vue3';
 import ItemCard from "@/Components/ItemCard.vue";
 import Pagination from "@/Components/Pagination.vue";
 
-defineOptions({ layout: MyPageLayoutVue })
-
 defineProps({
     items: Object,
+    user: Object,
 })
 </script>
 
 <template>
-    <div class="max-w-5xl mx-auto py-10 px-6">
-        <Head title="MyPage" />
-        <div class="flex flex-wrap">
-            <!-- 商品カード -->
-            <div v-for="item in items.data" :key="item.id" class="w-1/2 sm:w-1/4 md:w-1/5 p-2">
-                <ItemCard :item="item" />
+    <MyPageLayout :user="user">
+        <div class="max-w-5xl mx-auto py-10 px-6">
+            <Head title="MyPage" />
+            <div class="flex flex-wrap">
+                <!-- 商品カード -->
+                <div v-for="item in items.data" :key="item.id" class="w-1/2 sm:w-1/4 md:w-1/5 p-2">
+                    <ItemCard :item="item" />
+                </div>
             </div>
+            <Pagination :links="items.links" />
         </div>
-        <Pagination :links="items.links" />
-    </div>
+    </MyPageLayout>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,6 @@ Route::middleware('auth')->group(function () {
     Route::post('/api/like/{item_id}', [LikeController::class, 'store']);
     Route::delete('/api/like/{item_id}', [LikeController::class, 'destroy']);
     Route::get('/mypage', [MyPageController::class, 'index'])->name('mypage');
-    Route::get('/mypage/purchased', [MyPageController::class, 'showPurchased'])->name('mypage.purchased');
     Route::get('/mypage/profile', [ProfileController::class, 'edit'])->name('mypage.profile');
     Route::post('/mypage/profile', [ProfileController::class, 'update']);
     Route::get('/item/comment/{item_id}', [CommentController::class, 'index'])->name('item.comment');


### PR DESCRIPTION
## 【概要】
以下２点の修正を実施
・マイページ上部（MyPageLayout）でユーザーが設定した名前、画像が表示されるように修正
・「出品した商品」「購入した商品」それぞれ別URLで表示していたものを "/mypage" の共通URLのみに変更

## 【実装内容詳細】
- MyPage.vue から defineOptions({ layout: MyPageLayoutVue }) を削除し、templete内でMyPageLayoutコンポーネントを呼び出す形に変更（※MyPageLayoutにパラメータを渡せる様にする為の対応）
- MyPageLayout にユーザー情報のパラメータを渡し、設定されている「ユーザー名」「アイコン画像」を参照して表示するように対応
- 「出品した商品／購入した商品」表示時のルーティングを一つに共通化（ '/mypage/purchased' のルーティングを削除）
※タブ選択時にfilterパラメータとして "sell" or "purchased" を渡し、コントローラー側でどちらの商品一覧を取得するか条件分岐する形に処理を修正して対応