### PR TITLE
会員登録時にメール認証を通すように修正

### DIFF
--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -14,7 +14,7 @@ class EmailVerificationNotificationController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false));
+            return redirect()->intended(route('top', absolute: false));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -16,7 +16,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request): RedirectResponse|Response
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(route('dashboard', absolute: false))
+                    ? redirect()->intended(route('top', absolute: false))
                     : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -68,6 +68,6 @@ class RegisteredUserController extends Controller
             DB::rollBack();
         }
 
-        return redirect(route('top', absolute: false));
+        return redirect(route('verification.notice', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,13 +15,13 @@ class VerifyEmailController extends Controller
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+            return redirect()->intended(route('top', absolute: false).'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        return redirect()->intended(route('top', absolute: false).'?verified=1');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,9 +11,10 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Carbon\Carbon;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable, SoftDeletes;

--- a/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/resources/js/Pages/Auth/VerifyEmail.vue
@@ -22,40 +22,47 @@ const verificationLinkSent = computed(
 </script>
 
 <template>
-    <GuestLayout>
+    <div class="max-w-lg mx-auto mt-20 px-6">
         <Head title="Email Verification" />
 
-        <div class="mb-4 text-sm text-gray-600">
-            Thanks for signing up! Before getting started, could you verify your
-            email address by clicking on the link we just emailed to you? If you
-            didn't receive the email, we will gladly send you another.
-        </div>
-
-        <div
-            class="mb-4 text-sm font-medium text-green-600"
-            v-if="verificationLinkSent"
-        >
-            A new verification link has been sent to the email address you
-            provided during registration.
-        </div>
-
-        <form @submit.prevent="submit">
-            <div class="mt-4 flex items-center justify-between">
-                <PrimaryButton
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Resend Verification Email
-                </PrimaryButton>
-
-                <Link
-                    :href="route('logout')"
-                    method="post"
-                    as="button"
-                    class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                    >Log Out</Link
-                >
+        <div class="p-6 border rounded">
+            <div class="mb-4 text-lg font-bold text-gray-600">
+                ご登録頂きありがとうございます。<br>
+                メールアドレス確認のリンクを送付しましたので、メールに記載のボタンをクリックして、会員登録を完了してください。
             </div>
-        </form>
-    </GuestLayout>
+
+            <div class="mb-4 text-red-500">
+                <span>＜注意事項＞</span><br>
+                ボタン押下時、別のブラウザやメールアプリ等でページ表示される場合、認証処理が完了出来ません。その場合はメール最下部のURLをコピーし、このブラウザに直接貼り付けて認証を行って下さい。
+            </div>
+
+            <div
+                class="mb-4 text-green-600"
+                v-if="verificationLinkSent"
+            >
+                メールアドレス確認リンクを再送しました<br>
+                メールが届いていない場合はユーザ登録時に入力頂いたメールアドレスを再度ご確認下さい
+            </div>
+
+            <form @submit.prevent="submit">
+                <div class="mt-8 flex items-center justify-around flex-wrap gap-y-8">
+                    <PrimaryButton
+                        class="w-fit"
+                        :class="{ 'opacity-25': form.processing }"
+                        :disabled="form.processing"
+                    >
+                        メールアドレス確認リンクの再送
+                    </PrimaryButton>
+
+                    <Link
+                        :href="route('logout')"
+                        method="post"
+                        as="button"
+                        class="rounded-md text-sm font-bold text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        >ログアウト</Link
+                    >
+                </div>
+            </form>
+        </div>
+    </div>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,25 +17,13 @@ use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Admin\AdminCommentController;
 use App\Http\Controllers\Admin\AdminMailController;
 
-// Route::get('/', function () {
-//     return Inertia::render('Welcome', [
-//         'canLogin' => Route::has('login'),
-//         'canRegister' => Route::has('register'),
-//         'laravelVersion' => Application::VERSION,
-//         'phpVersion' => PHP_VERSION,
-//     ]);
-// });
+// Route::get('/test', function () { return Inertia::render('Test'); });
 
 Route::get('/', [TopPageController::class, 'index'])->name('top');
 Route::get('/item/{item_id}', [ItemDetailController::class, 'show'])->name('item.detail');
 
-// Route::get('/test', function () { return Inertia::render('Test'); });
-
 // 一般ユーザー向けページ
-Route::middleware('auth')->group(function () {
-    // Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-    // Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-    // Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+Route::middleware('verified', 'auth')->group(function () {
     Route::get('/mylist', [TopPageController::class, 'showMylist'])->name('top.mylist');
     Route::post('/api/like/{item_id}', [LikeController::class, 'store']);
     Route::delete('/api/like/{item_id}', [LikeController::class, 'destroy']);


### PR DESCRIPTION
## 【概要】
新規会員登録時のメール認証処理を追加実装

## 【実装内容詳細】
- UserモデルにMustVerifyEmailクラスを追記
- 登録ボタン押下直後のリダイレクト先を route('verification.notice') へ変更
	- app/Http/Controllers/Auth/RegisteredUserController.php
- 以下コントローラーのリダイレクト先がBreezeデフォルトの "dashboard" になっているのを "top" へ変更
	- app/Http/Controllers/Auth/EmailVerificationNotificationController.php
	- app/Http/Controllers/Auth/EmailVerificationPromptController.php
	- app/Http/Controllers/Auth/VerifyEmailController.php
- Breezeデフォルトの VerifyEmail.vue （「認証メールを送信しました」ページ）を日本語化して見た目を調整
- ルーティングのミドルウェアに 'verified' を追記