### PR TITLE
Fix/issue#004

### DIFF
--- a/app/Http/Controllers/Api/CheckoutSessionController.php
+++ b/app/Http/Controllers/Api/CheckoutSessionController.php
@@ -31,7 +31,7 @@ class CheckoutSessionController extends Controller
 
                     // 完了（購入済み）セッション  ※通常この状態は発生しないが保険の為
                     if ($session->status === 'complete') {
-                        $sold_item->update(['session_completed' => true]);
+                        $sold_item->update(['payment_completed' => true]);
                     }
                     // 決済前セッション  ※期限切れにして該当するsold_itemsレコードを削除
                     if ($session->status === 'open') {
@@ -55,7 +55,7 @@ class CheckoutSessionController extends Controller
 
                     // 「購入済み(決済完了済み)」判別処理
                     if ($session->status === 'complete') {
-                        $sold_item->update(['session_completed' => true]);
+                        $sold_item->update(['payment_completed' => true]);
                         return response()->json([
                             'status' => 'error',
                             'message' => 'この商品は既に売却済みです'
@@ -143,7 +143,7 @@ class CheckoutSessionController extends Controller
                 'item_id' => $item_id,
                 'payment_method_id' => $request->paymentMethodId,
                 'checkout_session_id' => $checkout->id,
-                'session_completed' => false,
+                'payment_completed' => false,
                 'ship_postcode' => $ship_postcode,
                 'ship_address' => $ship_address,
                 'ship_building' => $ship_building,
@@ -179,7 +179,7 @@ class CheckoutSessionController extends Controller
         SoldItem::where('checkout_session_id', $checkout_session_id)
                 ->first()
                 ->update([
-                    'session_completed' => true
+                    'payment_completed' => true
                 ]);
     }
 

--- a/app/Http/Controllers/Api/PaymentIntentController.php
+++ b/app/Http/Controllers/Api/PaymentIntentController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+use Stripe\StripeClient;
+use App\Models\Item;
+use App\Models\PaymentMethod;
+
+class PaymentIntentController extends Controller
+{
+    public function createPaymentIntent(Request $request): JsonResponse {
+        try {
+            $user = $request->user();
+            $item_id = $request->item_id;
+            $stripe = new StripeClient("sk_test_51QBad1Bli9nlS8GVTqk4Uty9r2jQqd3WwJlYOrZJZmNPZQWZBqPR4VOJNVPWaZMO88CJT7H9fDoXkJuIp6fTDo1K00UkjRgzAt");
+
+            // 登録住所の確認（無い場合はエラーを返す）
+            $ship_postcode = $user->profile->postcode;
+            $ship_address = $user->profile->address;
+            if (!$ship_postcode || !$ship_address) {
+                return response()->json([
+                    'status' => 'error',
+                    'message' => '配送先が正しく登録されていません'
+                ], 500);
+            }
+
+            DB::beginTransaction();
+
+            // 商品価格の取得
+            $price = Item::find($item_id)->price;
+
+            // Stripe顧客IDを取得（未作成の場合はここで作成）
+            $customer_id = $user->stripe_customer_id;
+            if ($customer_id === null) {
+                $customer = $stripe->customers->create([
+                    'name' => $user->name,
+                    'email' => $user->email,
+                ]);
+
+                $user->update([
+                    'stripe_customer_id' => $customer->id,
+                ]);
+
+                $customer_id = $customer->id;
+            }
+
+            // PaymentIntent作成
+            $intent = $stripe->paymentIntents->create([
+                'amount' => $price,
+                'customer' => $customer_id,
+                'currency' => 'jpy',
+                'payment_method_types'   => [PaymentMethod::find($request->paymentMethodId)->payment_method_type],
+                'payment_method_options' => [
+                    'card' => [
+                        'setup_future_usage' => 'on_session',
+                    ],
+                    'customer_balance' => [
+                        'funding_type' => 'bank_transfer',
+                        'bank_transfer' => [
+                            'type' => 'jp_bank_transfer',
+                        ],
+                    ]
+                ],
+            ]);
+
+            DB::commit();
+
+            return response()->json($intent);
+
+        } catch (\Exception $e) {
+            Log::error($e);
+            DB::rollBack();
+            return response()->json([
+                'status' => 'error',
+                'message' => 'エラーが発生しました'
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/SoldItemController.php
+++ b/app/Http/Controllers/Api/SoldItemController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use App\Models\Item;
+use App\Models\SoldItem;
+
+class SoldItemController extends Controller
+{
+    public function confirmStock(Request $request) {
+        try {
+            $item = Item::find($request->item_id);
+
+            return response()->json([
+                'status' => 'success',
+                'isSold' => $item->isSold(),
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error($e);
+            return response()->json([
+                'status' => 'error',
+                'message' => 'エラーが発生しました'
+            ], 500);
+        }
+    }
+
+    public function store(Request $request) {
+        try {
+            $user = $request->user();
+
+            // sold_itemテーブルにレコード登録
+            $sold_item = SoldItem::create([
+                'user_id' => $user->id,
+                'item_id' => $request->item_id,
+                'payment_method_id' => $request->paymentMethodId,
+                'payment_intent_id' => $request->paymentIntentId,
+                'payment_completed' => false,
+                'ship_postcode' => $user->profile->postcode,
+                'ship_address' => $user->profile->address,
+                'ship_building' => $user->profile->building,
+            ]);
+
+            return response()->json([
+                'status' => 'success',
+                'soldItemId' => $sold_item->id,
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error($e);
+            return response()->json([
+                'status' => 'error',
+                'message' => 'エラーが発生しました'
+            ], 500);
+        }
+    }
+
+    public function destroy(Request $request) {
+        try {
+            SoldItem::find($request->sold_item_id)->delete();
+            return response()->json([
+                'status' => 'success',
+            ]);
+        } catch (\Exception $e) {
+            Log::error($e);
+            return response()->json([
+                'status' => 'error',
+                'message' => 'エラーが発生しました'
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/PurchaseController.php
+++ b/app/Http/Controllers/PurchaseController.php
@@ -5,15 +5,20 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 use App\Services\ItemDetailService;
 use App\Models\PaymentMethod;
+use Stripe\StripeClient;
+use App\Models\Item;
+use App\Models\SoldItem;
 
 class PurchaseController extends Controller
 {
     public function create(Request $request) {
         // 商品情報
         $item = ItemDetailService::getItemDetail($request->item_id);
-        
+
         // 支払い方法一覧
         $paymentMethods = PaymentMethod::all()->pluck('name', 'id');
 
@@ -29,6 +34,141 @@ class PurchaseController extends Controller
             'item' => $item,
             'paymentMethods' => $paymentMethods,
             'shipAddress' => $ship_address,
+        ]);
+    }
+
+    // ----------------------------------------------------------------------------
+    // サーバー側で決済処理を実行する実装を行った際に使用した処理（最終的な実装では不使用）
+    // ----------------------------------------------------------------------------
+    // public function store(Request $request) {
+    //     try {
+    //         $user = $request->user();
+    //         $item_id = $request->item_id;
+    //         $stripe = new StripeClient("sk_test_51QBad1Bli9nlS8GVTqk4Uty9r2jQqd3WwJlYOrZJZmNPZQWZBqPR4VOJNVPWaZMO88CJT7H9fDoXkJuIp6fTDo1K00UkjRgzAt");
+
+    //         // 登録住所の確認（無い場合はエラーを返す）
+    //         $ship_postcode = $user->profile->postcode;
+    //         $ship_address = $user->profile->address;
+    //         $ship_building = $user->profile->building;
+    //         if (!$ship_postcode || !$ship_address) {
+    //             return to_route('purchase', $item_id)->with([
+    //                 'status' => 'error',
+    //                 'message' => '配送先が正しく登録されていません'
+    //             ]);
+    //         }
+
+    //         // 商品価格の取得
+    //         $price = Item::find($item_id)->price;
+
+    //         // Stripe顧客IDを取得（未作成の場合はここで作成してusersテーブルに登録）
+    //         $customer_id = $user->stripe_customer_id;
+    //         if ($customer_id === null) {
+    //             $customer = $stripe->customers->create([
+    //                 'name' => $user->name,
+    //                 'email' => $user->email,
+    //             ]);
+
+    //             $user->update([
+    //                 'stripe_customer_id' => $customer->id,
+    //             ]);
+
+    //             $customer_id = $customer->id;
+    //         }
+
+    //         DB::beginTransaction();
+
+    //         // StripeのpaymentIntents作成＆決済（作成と決済を同時に実行）
+    //         $intent = $stripe->paymentIntents->create([
+    //             'confirm' => true,
+    //             'amount' => $price,
+    //             'currency' => 'jpy',
+    //             'automatic_payment_methods' => ['enabled' => true],
+    //             'customer' => $customer_id,
+    //             'confirmation_token' => $request->confirmationTokenId,
+    //             'return_url' => route('top'),
+    //         ]);
+
+    //         // dd($intent);
+
+    //         // sold_itemテーブルにレコード登録
+    //         SoldItem::create([
+    //             'user_id' => $user->id,
+    //             'item_id' => $item_id,
+    //             'payment_method_id' => 1,  // 仮設定
+    //             'payment_intent_id' => $intent->id,
+    //             'payment_completed' => true,
+    //             'ship_postcode' => $ship_postcode,
+    //             'ship_address' => $ship_address,
+    //             'ship_building' => $ship_building,
+    //         ]);
+
+    //         DB::commit();
+
+    //         $status = 'success';
+    //         $message = '購入処理が完了しました';
+
+    //     } catch (\Exception $e) {
+    //         Log::error($e);
+
+    //         DB::rollBack();
+
+    //         $status = 'error';
+    //         $message = 'エラーが発生しました';
+    //     }
+
+    //     return to_route('purchase', $item_id)->with([
+    //         'status' => $status,
+    //         'message' => $message,
+    //     ]);
+    // }
+
+    public function confirmPaymentIntentStatus(Request $request) {
+        try {
+            $payment_intent_id = $request->payment_intent;
+            $sold_item = SoldItem::where('payment_intent_id', $payment_intent_id)->first();
+            $stripe = new StripeClient("sk_test_51QBad1Bli9nlS8GVTqk4Uty9r2jQqd3WwJlYOrZJZmNPZQWZBqPR4VOJNVPWaZMO88CJT7H9fDoXkJuIp6fTDo1K00UkjRgzAt");
+
+            $payment_intent = $stripe->paymentIntents->retrieve($payment_intent_id);
+
+            switch ($payment_intent->status) {
+                case 'succeeded': // クレジットカード決済の正常完了
+                    $status = 'success';
+                    $message = '購入処理が完了しました';
+                    // payment_completedの更新処理
+                    $sold_item->update(['payment_completed' => true]);
+                    break;
+
+                case 'requires_action': // 「コンビニ払い」「銀行振込」受付完了（この後ユーザーによる支払いが必要）
+                    $status = 'success';
+                    $message = '購入処理が完了しました';
+                    break;
+
+                case 'processing': // 今回の実装「カード」「コンビニ払い」「銀行振込」ではこのステータスは想定外
+                    $status = 'processing';
+                    $message = '支払い処理中です。しばらくお待ちください';
+                    break;
+
+                case 'requires_payment_method': // 今回の実装「カード」「コンビニ払い」「銀行振込」ではこのステータスは想定外
+                    $status = 'error';
+                    $message = '支払いに失敗しました。別の支払い方法をお試しください';
+                    // sold_itemレコードの削除処理
+                    $sold_item->delete();
+                    break;
+
+                default: // 上記何れにも該当しない（＝予期せぬ不明なエラー発生時）の想定
+                    $status = 'error';
+                    $message = '問題が発生しました';
+                    // sold_itemレコードの削除処理
+                    $sold_item->delete();
+                    break;
+            }
+        } catch (\Exception $e) {
+            Log::error($e);
+        }
+
+        return to_route('purchase', $request->item_id)->with([
+            'status' => $status,
+            'message' => $message,
         ]);
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -80,7 +80,7 @@ class Item extends Model
     }
 
     public function isSold(): bool {
-        $sold_items = $this->soldItems->where('session_completed', true);
+        $sold_items = $this->soldItems;
         return $sold_items->isNotEmpty();
     }
 }

--- a/app/Models/SoldItem.php
+++ b/app/Models/SoldItem.php
@@ -16,7 +16,7 @@ class SoldItem extends Model
     protected function casts(): array
     {
         return [
-            'session_completed' => 'boolean',
+            'payment_completed' => 'boolean',
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -96,7 +96,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function checkoutItems(): BelongsToMany {
         return $this->belongsToMany('App\Models\Item', 'sold_items')
-                    ->withPivot('session_completed');
+                    ->withPivot('payment_completed');
     }
 
     public function profile(): HasOne {
@@ -109,7 +109,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function getPurchasedItems() {
         $items = $this->checkoutItems->filter(function($item) {
-            return $item->pivot->session_completed;
+            return $item->pivot->payment_completed;
         });
         return $items;
     }

--- a/database/migrations/2024_12_20_163331_create_sold_items_table.php
+++ b/database/migrations/2024_12_20_163331_create_sold_items_table.php
@@ -16,8 +16,8 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained();
             $table->foreignId('item_id')->constrained()->unique();
             $table->foreignId('payment_method_id')->constrained();
-            $table->string('checkout_session_id')->unique();
-            $table->boolean('session_completed');
+            $table->string('payment_intent_id')->unique();
+            $table->boolean('payment_completed');
             $table->string('ship_postcode');
             $table->string('ship_address');
             $table->string('ship_building')->nullable();

--- a/resources/js/Components/PurchaseButton.vue
+++ b/resources/js/Components/PurchaseButton.vue
@@ -1,0 +1,144 @@
+<script setup>
+import { ref, onUnmounted } from 'vue'
+import { router } from '@inertiajs/vue3'
+import axios from 'axios'
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import { loadStripe } from '@stripe/stripe-js'
+import ErrorModal from "@/Components/ErrorModal.vue";
+
+const props = defineProps({
+    itemId: Number,
+    paymentMethodId: Number,
+});
+
+const stripeKey = "pk_test_51QBad1Bli9nlS8GV0wskk4eK8OoTM6vLGUuQ7igRELuoB3B4YlbN4ubnUKFPaFeXeTqju80TN1vyXrMS7LWFY4zb00Pd2mQYT5";
+const stripeInstance = ref(null);
+const stripeElements = ref(null);
+const stripePaymentIntentId = ref(null);
+
+const open = ref(false);
+
+const showErrorModal = ref(false);
+const errorMessage = ref('');
+
+async function showForm() {
+    const stripe = await loadStripe(stripeKey);
+
+    await axios
+        .post('/api/purchase/' + props.itemId, {
+            paymentMethodId: props.paymentMethodId,
+        })
+        .then(async (res) => {
+            open.value = true;
+
+            const options = {
+                clientSecret: res.data.client_secret,
+                appearance: {/*...*/},
+            };
+            const elements = stripe.elements(options);
+            const paymentElementOptions = { layout: 'accordion'};
+            const paymentElement = await elements.create('payment', paymentElementOptions);
+            paymentElement.mount('#checkout');
+
+            // 作成済みStripeインスタンス、エレメントを一時保存
+            stripeInstance.value = stripe;
+            stripeElements.value = elements;
+            stripePaymentIntentId.value = res.data.id;
+        })
+        .catch(function (error) {
+            router.reload();
+            showError(error.response.data.message)
+        })
+}
+
+async function submit() {
+    try {
+        // 売り切れ確認
+        await axios
+            .get('/api/purchase/sold_item/' + props.itemId)
+            .then(async (res) => {
+                if (res.data.isSold) {
+                    throw new Error('この商品は既に売却済みです');
+                }
+            })
+            .catch(function (error) {
+                hide();
+                throw new Error(error.message);
+            })
+
+        // sold_itemへ登録
+        const soldItemId = ref(null);
+        await axios
+            .post('/api/purchase/sold_item/' + props.itemId, {
+                paymentMethodId: props.paymentMethodId,
+                paymentIntentId: stripePaymentIntentId.value,
+            })
+            .then(async (res) => {
+                soldItemId.value = res.data.soldItemId;
+            })
+            .catch(function (error) {
+                throw new Error('エラーが発生しました');
+            })
+
+        // PaymentIntentの確認
+        const stripe = stripeInstance.value;
+        const elements = stripeElements.value;
+        const {error} = await stripe.confirmPayment({
+            elements,
+            confirmParams: {
+                return_url: route('purchase.complete', props.itemId),
+            },
+        });
+
+        // PaymentIntent確認失敗時のエラー処理
+        if (error) {
+            // sold_itemレコード削除
+            await axios
+                .delete('/api/purchase/sold_item/' +  soldItemId.value)
+                .catch(function (error) {
+                    throw new Error('エラーが発生しました');
+                })
+
+            throw new Error(error.message);
+        }
+
+    } catch (e) {
+        showError(e.message);
+    }
+}
+
+async function hide() {
+    open.value = false;
+}
+
+async function showError(message) {
+    errorMessage.value = message;
+    showErrorModal.value = true;
+}
+</script>
+
+<template>
+    <div>
+        <div>
+            <PrimaryButton @click="showForm()">購入する</PrimaryButton>
+        </div>
+
+        <Teleport to="body">
+            <div
+                v-if="open"
+                class="fixed top-0 right-0 bottom-0 left-0 bg-[rgba(0,0,0,.3)]"
+            >
+                <div class="fixed top-1/2 left-1/2 z-50 bg-white translate-y-[-50%] translate-x-[-50%] drop-shadow-xl py-10 px-20 max-sm:px-6 max-h-[85vh] overflow-auto w-max">
+                    <form @submit.prevent="submit()">
+                        <div id="checkout"></div>
+                        <PrimaryButton class="mt-10">支払う</PrimaryButton>
+                    </form>
+                    <button @click="hide()" class="block w-3/4 mx-auto mt-10">Close</button>
+                </div>
+            </div>
+        </Teleport>
+
+        <ErrorModal v-model="showErrorModal">{{ errorMessage }}</ErrorModal>
+
+    </div>
+</template>

--- a/resources/js/Components/StripePurchaseButton.vue
+++ b/resources/js/Components/StripePurchaseButton.vue
@@ -1,0 +1,115 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { router, usePage } from '@inertiajs/vue3'
+import { loadStripe } from '@stripe/stripe-js'
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import FlashMassageModal from "@/Components/FlashMassageModal.vue";
+
+const props = defineProps({
+    item: Object,
+    paymentMethodId: Number,
+});
+
+const stripeKey = "pk_test_51QBad1Bli9nlS8GV0wskk4eK8OoTM6vLGUuQ7igRELuoB3B4YlbN4ubnUKFPaFeXeTqju80TN1vyXrMS7LWFY4zb00Pd2mQYT5";
+const stripeInstance = ref(null);
+const stripeElements = ref(null);
+
+const open = ref(false);
+
+const showFlashMessage = ref(false);
+const message = computed(() => usePage().props.flash.message);
+const status = computed(() => usePage().props.flash.status);
+
+async function showForm() {
+    open.value = true;
+
+    const stripe = await loadStripe(stripeKey);
+
+    const options = {
+        mode: 'payment',
+        amount: props.item.price,
+        currency: 'jpy',
+        paymentMethodCreation: 'manual',
+        // Fully customizable with appearance API.
+        appearance: {/*...*/},
+    };
+    const elements = stripe.elements(options);
+    const paymentElementOptions = {
+        layout: 'tabs',
+        paymentMethodOrder: ['konbini'],
+    };
+    const paymentElement = await elements.create('payment', paymentElementOptions);
+    paymentElement.mount('#checkout');
+
+    // 作成済みStripeインスタンス、エレメントを一時保存
+    stripeInstance.value = stripe;
+    stripeElements.value = elements;
+}
+
+async function submit() {
+    const stripe = stripeInstance.value;
+    const elements = stripeElements.value;
+
+    // stripeElementsのsubmit処理
+    const {error: submitError} = await elements.submit();
+    // エラー処理
+    if (submitError) {
+        console.log(error);
+        return;
+    }
+
+    // ConfirmationTokenの作成
+    const {error, confirmationToken} = await stripe.createConfirmationToken({
+        elements,
+    });
+    // エラー処理
+    if (error) {
+        console.log(error);
+        return;
+    }
+
+    console.log(confirmationToken);
+
+    // ConfirmationTokenをサーバーへ送信
+    router.post(route('purchase', props.item.id), { confirmationTokenId: confirmationToken.id }, {
+        onError: (errors) => {console.log( errors ) },
+        onFinish: visit => {
+            open.value = false;
+            showFlashMessage.value = true;
+        },
+    });
+}
+
+async function hide() {
+    open.value = false;
+}
+</script>
+
+<template>
+    <div>
+        <div>
+            <PrimaryButton @click="showForm()">購入する（サーバー決済対応）</PrimaryButton>
+        </div>
+
+        <Teleport to="body">
+            <div
+                v-if="open"
+                class="fixed top-0 right-0 bottom-0 left-0 bg-[rgba(0,0,0,.3)]"
+            >
+                <div class="fixed top-1/2 left-1/2 z-50 bg-white translate-y-[-50%] translate-x-[-50%] drop-shadow-xl py-10 px-20 max-sm:px-6 max-h-[85vh] overflow-auto w-max">
+                    <form @submit.prevent="submit()">
+                        <div id="checkout"></div>
+                        <PrimaryButton class="mt-10">支払う</PrimaryButton>
+                    </form>
+                    <button @click="hide()" class="block w-3/4 mx-auto mt-10">Close</button>
+                </div>
+            </div>
+        </Teleport>
+
+        <!-- フラッシュメッセージモーダル -->
+        <FlashMassageModal v-model:status="status" v-model:show="showFlashMessage">
+            {{ message }}
+        </FlashMassageModal>
+
+    </div>
+</template>

--- a/resources/js/Pages/Purchase.vue
+++ b/resources/js/Pages/Purchase.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { Head, Link } from '@inertiajs/vue3';
-import { ref } from 'vue'
+import { Head, Link, usePage } from '@inertiajs/vue3';
+import { ref, computed } from 'vue'
 import ItemImage from "@/Components/ItemImage.vue";
-import StripeCheckoutButton from "@/Components/StripeCheckoutButton.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
+import PurchaseButton from "@/Components/PurchaseButton.vue";
+import FlashMassageModal from "@/Components/FlashMassageModal.vue";
 
 const props = defineProps({
     item: Object,
@@ -13,6 +14,10 @@ const props = defineProps({
 
 const open = ref(false);
 const selectedId = ref(1);
+
+const showFlashMessage = ref(true);
+const message = computed(() => usePage().props.flash.message);
+const status = computed(() => usePage().props.flash.status);
 </script>
 
 <template>
@@ -91,9 +96,7 @@ const selectedId = ref(1);
                     <PrimaryButton v-if="item.is_sold === true" disabled>
                         SOLD OUT
                     </PrimaryButton>
-                    <StripeCheckoutButton v-else :itemId="item.id" :paymentMethodId="selectedId">
-                        購入する
-                    </StripeCheckoutButton>
+                    <PurchaseButton v-else :itemId="item.id" :paymentMethodId="selectedId" class="mt-5" />
                 </div>
             </div>
         </div>
@@ -113,5 +116,10 @@ const selectedId = ref(1);
                 </div>
             </div>
         </Teleport>
+
+        <!-- フラッシュメッセージモーダル -->
+        <FlashMassageModal v-if="status" v-model:status="status" v-model:show="showFlashMessage">
+            {{ message }}
+        </FlashMassageModal>
     </div>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,8 @@ use App\Http\Controllers\SellController;
 use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Admin\AdminCommentController;
 use App\Http\Controllers\Admin\AdminMailController;
+use App\Http\Controllers\Api\PaymentIntentController;
+use App\Http\Controllers\Api\SoldItemController;
 
 // Route::get('/test', function () { return Inertia::render('Test'); });
 
@@ -32,9 +34,14 @@ Route::middleware('verified', 'auth')->group(function () {
     Route::post('/mypage/profile', [ProfileController::class, 'update']);
     Route::get('/item/comment/{item_id}', [CommentController::class, 'index'])->name('item.comment');
     Route::post('/item/comment/{item_id}', [CommentController::class, 'store']);
-    Route::post('/api/purchase/{item_id}', [CheckoutSessionController::class, 'createCheckoutSession']);
+
+    Route::post('/api/purchase/{item_id}', [PaymentIntentController::class, 'createPaymentIntent']);
+    Route::get('/api/purchase/sold_item/{item_id}', [SoldItemController::class, 'confirmStock']);
+    Route::post('/api/purchase/sold_item/{item_id}', [SoldItemController::class, 'store']);
+    Route::delete('/api/purchase/sold_item/{sold_item_id}', [SoldItemController::class, 'destroy']);
+    Route::get('/purchase/complete/{item_id}', [PurchaseController::class, 'confirmPaymentIntentStatus'])->name('purchase.complete');
+
     Route::delete('/api/purchase/{checkout_session_id}', [CheckoutSessionController::class, 'expireCheckoutSession']);
-    Route::post('/api/purchase/completed/{checkout_session_id}', [CheckoutSessionController::class, 'completeCheckoutSession']);
     Route::get('/purchase/{item_id}', [PurchaseController::class, 'create'])->name('purchase');
     Route::get('/purchase/address/{item_id}', [ShipAddressController::class, 'edit'])->name('purchase.address');
     Route::post('/purchase/address/{item_id}', [ShipAddressController::class, 'update']);


### PR DESCRIPTION
## 【概要】
checkout session を使用した決済処理を行っていたが、このままでは「コンビニ払い」「銀行振込」の場合に別ページへリダイレクトされてonCompletedの処理を通らないため、DB上で "売却済み" に変更されない問題が発生していた
この問題を解消する為、「stripe checkout」をやめて新たに「stripe elements」を使用した実装方法へ変更する形で修正を実施

## 【実装内容詳細】
- 「stripe elements」を使用した実装方法へ変更する為、以下を新たに追加
	- 購入ボタン用コンポーネント：PurchaseButton.vue
	- PaymentIntent作成API：PaymentIntentController.php
	- sold_itemテーブル操作用API：SoldItemController.php
	- 決済完了時の処理：PurchaseController::class, 'cofirmPaymentIntentStatus'
- checkout session 不使用となった為、sold_itemテーブルのカラム名を以下の通り変更
	　旧）checkout_session_id, session_completed
	　新）payment_intent_id, payment_completed
- 上記カラム名の変更に伴い関連箇所も名称を修正
	- User.php
	- Item.php
	- SoldItem.php
	- CheckoutSessionController.php