### PR TITLE
ItemCard.vueコンポーネントから「SOLD OUT」表示を削除

### DIFF
--- a/resources/js/Components/ItemCard.vue
+++ b/resources/js/Components/ItemCard.vue
@@ -27,10 +27,6 @@ defineProps({
             >
                 <span class="opacity-100 text-white font-bold">￥{{ item.price }}</span>
             </div>
-            <!-- SOLD OUTアイコン -->
-            <div v-if="item.is_sold" class="w-20 absolute top-0 left-0">
-                <img src="img/sold_out.png" alt="">
-            </div>
         </div>
         <!-- 商品名 -->
         <span>{{ item.name }}</span>


### PR DESCRIPTION
## 【概要】
「SOLD OUT」アイコン表示が「ItemCard.vue」と「ItemImage.vue」両方に記述されている問題を修正

## 【実装内容詳細】
- 「ItemCard.vue」から「SOLD OUT」アイコン表示の記述を削除