### PR TITLE
Fix/issue#002

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -53,13 +53,19 @@ class ProfileController extends Controller
 
             $profile = $request->user()->profile;
             $profile->update($param);
+
+            $status = 'success';
+            $message = 'プロフィールを編集しました';
         } catch (\Exception $e) {
             Log::error($e);
+
+            $status = 'error';
+            $message = 'プロフィール編集に失敗しました';
         }
 
-        return Inertia::render('Profile', [
-            'userName' => $request->user()->name,
-            'profile' => $profile,
+        return to_route('mypage')->with([
+            'status' => $status,
+            'message' => $message,
         ]);
     }
 }

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -71,11 +71,20 @@ class SellController extends Controller
             $item->categories()->attach($request->categories);
 
             DB::commit();
+
+            $status = 'success';
+            $message = '出品しました';
         } catch (\Exception $e) {
             Log::error($e);
             DB::rollBack();
+
+            $status = 'error';
+            $message = '出品に失敗しました';
         }
 
-        return to_route('top');
+        return to_route('item.detail', $item->id)->with([
+            'status' => $status,
+            'message' => $message,
+        ]);
     }
 }

--- a/resources/js/Components/FlashMessageModal.vue
+++ b/resources/js/Components/FlashMessageModal.vue
@@ -1,9 +1,10 @@
 <script setup>
-import { ref, onUpdated } from 'vue'
+import { ref, onUpdated, onMounted, computed } from 'vue'
+import { usePage } from '@inertiajs/vue3';
 
-const status = defineModel('status', {
-    type: String,
-});
+// const status = defineModel('status', {
+//     type: String,
+// });
 
 const show = defineModel('show', {
     type: Boolean,
@@ -11,7 +12,17 @@ const show = defineModel('show', {
     default: false,
 });
 
+const message = computed(() => usePage().props.flash.message);
+const status = computed(() => usePage().props.flash.status);
 const timeId = ref(0);
+
+onMounted(() => {
+    if (show.value === true) {
+        timeId.value = setTimeout(() => {
+            show.value = false;
+        }, 3000);
+    }
+});
 
 onUpdated(() => {
     if (show.value === true) {
@@ -32,7 +43,7 @@ function closeModal() {
         <Teleport to="body">
             <Transition>
                 <div
-                    v-if="show"
+                    v-if="show && message"
                     class="fixed top-14 right-6 md:right-20 z-50 drop-shadow-xl py-4 px-8 rounded bg-gray-600"
                     :class = "{
                         'bg-red-500' : status == 'error',
@@ -41,7 +52,7 @@ function closeModal() {
                 >
                     <div class="flex items-center text-white font-bold">
                         <img src="/img/error_icon.svg" class="w-5 mr-2">
-                        <slot />
+                        {{ message }}
                         <button @click="closeModal()" class="ml-6 p-2 rounded-full hover:bg-red-400">
                             <img src="/img/cross_icon.svg" class="w-3">
                         </button>

--- a/resources/js/Pages/Admin/AdminComment.vue
+++ b/resources/js/Pages/Admin/AdminComment.vue
@@ -27,8 +27,6 @@ const selectedUserName = ref('');
 const selectedComment = ref('')
 
 const showFlashMessage = ref(false);
-const message = computed(() => usePage().props.flash.message);
-const status = computed(() => usePage().props.flash.status);
 
 function searchComment() {
     router.reload({
@@ -169,9 +167,7 @@ function deleteComment(id) {
         </Teleport>
 
         <!-- フラッシュメッセージモーダル -->
-        <FlashMessageModal v-model:status="status" v-model:show="showFlashMessage">
-            {{ message }}
-        </FlashMessageModal>
+        <FlashMessageModal v-model:show="showFlashMessage" />
 
     </div>
 </template>

--- a/resources/js/Pages/Admin/AdminMail.vue
+++ b/resources/js/Pages/Admin/AdminMail.vue
@@ -22,8 +22,6 @@ const form = useForm({
 });
 
 const showFlashMessage = ref(false);
-const message = computed(() => usePage().props.flash.message);
-const status = computed(() => usePage().props.flash.status);
 
 function submit() {
     form.post(route('admin.mail'));
@@ -60,9 +58,7 @@ function submit() {
         </form>
 
         <!-- フラッシュメッセージモーダル -->
-        <FlashMessageModal v-model:status="status" v-model:show="showFlashMessage">
-            {{ message }}
-        </FlashMessageModal>
+        <FlashMessageModal v-model:show="showFlashMessage" />
 
     </div>
 </template>

--- a/resources/js/Pages/Admin/AdminUser.vue
+++ b/resources/js/Pages/Admin/AdminUser.vue
@@ -25,8 +25,6 @@ const selectedId = ref(null);
 const selectedName = ref('');
 
 const showFlashMessage = ref(false);
-const message = computed(() => usePage().props.flash.message);
-const status = computed(() => usePage().props.flash.status);
 
 function searchUser() {
     router.reload({
@@ -156,9 +154,7 @@ function deleteUser(id) {
         </Teleport>
 
         <!-- フラッシュメッセージモーダル -->
-        <FlashMessageModal v-model:status="status" v-model:show="showFlashMessage">
-            {{ message }}
-        </FlashMessageModal>
+        <FlashMessageModal v-model:show="showFlashMessage" />
 
     </div>
 </template>

--- a/resources/js/Pages/ItemDetail.vue
+++ b/resources/js/Pages/ItemDetail.vue
@@ -1,15 +1,19 @@
 <script setup>
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, usePage } from '@inertiajs/vue3';
+import { ref, computed } from 'vue'
 import ItemImage from "@/Components/ItemImage.vue";
 import LikeIcon from "@/Components/LikeIcon.vue";
 import CommentIcon from "@/Components/CommentIcon.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 import CategoryIcon from "@/Components/CategoryIcon.vue";
+import FlashMessageModal from "@/Components/FlashMessageModal.vue";
 
 const props = defineProps({
     item: Object,
 });
 const price = `￥${props.item.price.toLocaleString()}`;
+const showFlashMessage = ref(true);
+const message = computed(() => usePage().props.flash.message);
 </script>
 
 <template>
@@ -48,7 +52,7 @@ const price = `￥${props.item.price.toLocaleString()}`;
                     <div class="mt-8 flex items-center flex-wrap gap-4">
                         <span class="font-bold">カテゴリー</span>
                         <div class="flex flex-wrap gap-2">
-                            <CategoryIcon v-for="name in item.category_names">
+                            <CategoryIcon v-for="name in item.category_names" :key="name">
                                 {{ name }}
                             </CategoryIcon>
                         </div>
@@ -60,5 +64,8 @@ const price = `￥${props.item.price.toLocaleString()}`;
                 </div>
             </div>
         </div>
+
+        <!-- フラッシュメッセージモーダル -->
+        <FlashMessageModal v-if="message" v-model:show="showFlashMessage" />
     </div>
 </template>

--- a/resources/js/Pages/MyPage.vue
+++ b/resources/js/Pages/MyPage.vue
@@ -1,13 +1,18 @@
 <script setup>
 import MyPageLayout from '@/Layouts/MyPageLayout.vue';
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, usePage } from '@inertiajs/vue3';
+import { ref, computed } from 'vue'
 import ItemCard from "@/Components/ItemCard.vue";
 import Pagination from "@/Components/Pagination.vue";
+import FlashMessageModal from "@/Components/FlashMessageModal.vue";
 
 defineProps({
     items: Object,
     user: Object,
 })
+
+const showFlashMessage = ref(true);
+const message = computed(() => usePage().props.flash.message);
 </script>
 
 <template>
@@ -21,6 +26,9 @@ defineProps({
                 </div>
             </div>
             <Pagination :links="items.links" />
+
+            <!-- フラッシュメッセージモーダル -->
+            <FlashMessageModal v-if="message" v-model:show="showFlashMessage" />
         </div>
     </MyPageLayout>
 </template>

--- a/resources/js/Pages/Purchase.vue
+++ b/resources/js/Pages/Purchase.vue
@@ -24,7 +24,6 @@ const shipAddressModal = reactive({
 
 const showFlashMessage = ref(true);
 const message = computed(() => usePage().props.flash.message);
-const status = computed(() => usePage().props.flash.status);
 
 function deleteAddress(addressId) {
     router.delete(route('purchase.address.edit', addressId), {
@@ -162,8 +161,6 @@ function deleteAddress(addressId) {
         </Teleport>
 
         <!-- フラッシュメッセージモーダル -->
-        <FlashMessageModal v-if="status" v-model:status="status" v-model:show="showFlashMessage">
-            {{ message }}
-        </FlashMessageModal>
+        <FlashMessageModal v-if="message" v-model:show="showFlashMessage" />
     </div>
 </template>


### PR DESCRIPTION
## 【概要】
出品時、プロフィール編集時のフラッシュメッセージ対応

## 【実装内容詳細】
- フラッシュメッセージのメッセージ＆ステータスの取得をFlashMessageModal.vueの中で行う様に修正
（ページ側で変数を持つ必要が無い様にする為）
- 出品時の戻り先を商品詳細ページへ変更
- プロフィール編集時の戻り先をマイページへ変更
- 出品時、プロフィール編集時にフラッシュメッセージが表示されるように対応
