### PR TITLE
Fix/issue#007

### DIFF
--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -24,7 +24,7 @@ class ProfileUpdateRequest extends FormRequest
                 'extensions:jpeg,jpg,png,bmp',
                 'max:10240'
             ],
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:50'],
             'postcode' => ['nullable', 'regex:/^[0-9]+$/', 'digits:7'],
             'address' => ['nullable', 'string', 'max:255'],
             'building' => ['nullable', 'string', 'max:255'],

--- a/resources/js/Pages/Comment.vue
+++ b/resources/js/Pages/Comment.vue
@@ -21,9 +21,9 @@ const form = useForm({
 
 function submit() {
     form.post('/item/comment/' + props.item.id, {
-        preserveScroll: true
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
     });
-    form.comment = null;
 };
 </script>
 


### PR DESCRIPTION
## 【概要】
テキスト登録時の最大文字数について不適切な設定となっている箇所（文字数が多すぎる箇所）を修正

## 【実装内容詳細】
- コメント入力で文字数エラー発生時、入力欄がリセットされないように修正
- プロフィールの名前の最大文字数を50文字に修正