### PR TITLE
Fix/issue#001

### DIFF
--- a/resources/js/Components/SearchItems.vue
+++ b/resources/js/Components/SearchItems.vue
@@ -5,10 +5,11 @@ import { router } from '@inertiajs/vue3'
 const searchWord = ref('')
 
 function search() {
-    router.get('/', { searchWord: searchWord.value })
+    router.get('/', { searchWord: searchWord.value }, {
+        onFinish: () => { searchWord.value = null },
+    });
 }
 </script>
-
 
 <template>
     <input

--- a/resources/js/Pages/Top.vue
+++ b/resources/js/Pages/Top.vue
@@ -14,8 +14,16 @@ defineProps({
 <template>
     <div class="max-w-5xl mx-auto py-10 px-6">
         <Head title="Top Page" />
+
+        <!-- 検索条件表示 -->
+        <div v-if="route().params.searchWord" class="mb-4 px-2">
+            <div class="font-bold py-1 px-4 bg-gradient-to-t from-zinc-300 to-zinc-100">
+                検索条件 : "{{ route().params.searchWord }}"
+            </div>
+        </div>
+
+        <!-- 商品一覧 -->
         <div class="flex flex-wrap">
-            <!-- 商品カード -->
             <div v-for="item in items.data" :key="item.id" class="w-1/2 sm:w-1/4 md:w-1/5 p-2">
                 <ItemCard :item="item" />
             </div>


### PR DESCRIPTION
## 【概要】
商品検索後、マイリストに遷移すると検索ボックスの入力文字が残ったままになる問題を修正

## 【実装内容詳細】
- 商品検索時、検索ワードの入力欄をリセットするように修正
- 商品検索時、結果一覧の上部に検索ワードを表示するように修正