### PR TITLE
Feature/user page test

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -38,7 +38,7 @@ class CommentController extends Controller
      * @return RedirectResponse
      */
     public function store(CommentRequest $request): RedirectResponse
-            {
+    {
         try {
             Comment::create([
                 'user_id' => $request->user()->id,

--- a/app/Http/Controllers/PurchaseController.php
+++ b/app/Http/Controllers/PurchaseController.php
@@ -60,10 +60,18 @@ class PurchaseController extends Controller
      */
     public function confirmPaymentIntentStatus(Request $request): RedirectResponse
     {
+        // 不正アクセス対策
+        if (!$request->payment_intent) { return to_route('top'); }
+
         try {
             $payment_intent_id = $request->payment_intent;
             $sold_item = SoldItem::where('payment_intent_id', $payment_intent_id)->first();
             $stripe = new StripeClient(config('stripe.stripe_secret'));
+
+            // sold_itemレコードが意図したものか念のため確認
+            if ($sold_item->user_id !== $request->user()->id || $sold_item->item_id !== $request->item_id) {
+                return to_route('top');
+            }
 
             $payment_intent = $stripe->paymentIntents->retrieve($payment_intent_id);
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -21,7 +21,7 @@ class RegistrationTest extends TestCase
     {
         $response = $this->post('/register', [
             'name' => 'Test User',
-            'email' => 'test@example.com',
+            'email' => 'test@example.net',
             'password' => 'password',
         ]);
 

--- a/tests/Feature/UserPage/CommentTest.php
+++ b/tests/Feature/UserPage/CommentTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Comment;
+
+class CommentTest extends TestCase
+{
+    public function test_コメントページ表示(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+
+        $response = $this->actingAs($user)->get(route('item.comment', $item_id));
+
+        $response->assertOk();
+    }
+
+    public function test_コメント投稿(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+        $comment = 'test';
+
+        $response = $this->actingAs($user)->post(route('item.comment', [
+            'item_id' => $item_id,
+            'comment' => $comment,
+        ]));
+
+        $response->assertRedirect(route('item.comment', $item_id));
+        $this->assertDatabaseHas(Comment::class, [
+            'user_id' => 1,
+            'item_id' => $item_id,
+            'comment' => $comment,
+        ]);
+    }
+}

--- a/tests/Feature/UserPage/EditShipAddressTest.php
+++ b/tests/Feature/UserPage/EditShipAddressTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Address;
+
+class EditShipAddressTest extends TestCase
+{
+    public function test_配送先編集ページ表示(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+        $address = Address::create([
+            'user_id' => $user->id,
+            'name' => 'テスト配送先宛名',
+            'postcode' => '1234567',
+            'address' => 'テスト配送先住所 99-99-99',
+            'building' => 'テスト配送先建物名 9999号室',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('purchase.address.edit', [
+            'address_id' => $address->id,
+            'item_id' => $item_id,
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_不正なアドレスIDでアクセスされた場合のリダイレクト(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+        $address_id = 0;
+
+        $response = $this->actingAs($user)->get(route('purchase.address.edit', [
+            'address_id' => $address_id,
+            'item_id' => $item_id,
+        ]));
+
+        $response->assertRedirect(route('top'));
+    }
+
+    public function test_配送先編集処理(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+        $address = Address::create([
+            'user_id' => $user->id,
+            'name' => 'テスト配送先宛名',
+            'postcode' => '1234567',
+            'address' => 'テスト配送先住所 99-99-99',
+            'building' => 'テスト配送先建物名 9999号室',
+        ]);
+        $param = [
+            'address_id' => $address->id,
+            'item_id' => $item_id,
+        ];
+        $form_edited = [
+            'user_id' => $user->id,
+            'name' => 'edited_テスト配送先宛名',
+            'postcode' => '9999999',
+            'address' => 'edited_テスト配送先住所 99-99-99',
+            'building' => 'edited_テスト配送先建物名 9999号室',
+        ];
+
+        $response = $this->actingAs($user)->post(route('purchase.address.edit', array_merge($param, $form_edited)));
+
+        $response->assertRedirect(route('purchase', ['item_id' => $item_id, 'modalOpen' => true]));
+        $this->assertDatabaseHas(Address::class, $form_edited);
+    }
+
+    public function test_配送先編集削除(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+        $address = Address::create([
+            'user_id' => $user->id,
+            'name' => 'テスト配送先宛名',
+            'postcode' => '1234567',
+            'address' => 'テスト配送先住所 99-99-99',
+            'building' => 'テスト配送先建物名 9999号室',
+        ]);
+        $param = [
+            'address_id' => $address->id,
+            'item_id' => $item_id,
+        ];
+
+        $response = $this->actingAs($user)->delete(route('purchase.address.edit', $param));
+
+        $response->assertRedirect(route('purchase', ['item_id' => $item_id, 'modalOpen' => true]));
+        $this->assertDatabaseMissing(Address::class, [
+            'id' => $address->id,
+        ]);
+    }
+}

--- a/tests/Feature/UserPage/ItemDetailTest.php
+++ b/tests/Feature/UserPage/ItemDetailTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+
+class ItemDetailTest extends TestCase
+{
+    public function test_未ログイン状態での商品詳細ページ表示(): void
+    {
+        $item_id = Item::inRandomOrder()->first()->id;
+
+        $response = $this->get(route('item.detail', $item_id));
+
+        $response->assertOk();
+    }
+
+    public function test_ログイン済み状態での商品詳細ページ表示(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+
+        $response = $this->actingAs($user)->get(route('item.detail', $item_id));
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/UserPage/MyPageTest.php
+++ b/tests/Feature/UserPage/MyPageTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\SoldItem;
+use Inertia\Testing\AssertableInertia;
+
+class MyPageTest extends TestCase
+{
+    public function test_マイページ表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('mypage'));
+
+        $response->assertOk();
+    }
+
+    public function test_出品した商品タブ表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('mypage', ['filter' => 'sell']));
+
+        $response->assertOk();
+    }
+
+    public function test_購入した商品タブ表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('mypage', ['filter' => 'purchased']));
+
+        $response->assertOk();
+    }
+
+    public function test_出品した商品タブで表示されるのは自身の出品商品のみ(): void
+    {
+        Item::create([
+            'name' => 'test',
+            'price' => '1000',
+            'description' => 'test',
+            'image_url' => '/img/dummy_item.png',
+            'condition_id' => '1',
+            'user_id' => '2',
+            'stripe_price_id' => 'price_dummy',
+        ]);
+        $user = User::find(1);
+        $count = Item::where('user_id', $user->id)->count();
+
+        $response = $this->actingAs($user)->get(route('mypage', ['filter' => 'sell']));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($count) {
+            $page->component('MyPage')
+                 ->where('items.total', $count);
+        });
+    }
+
+    public function test_購入した商品タブで表示されるのは自身の購入商品のみ(): void
+    {
+        $user = User::find(1);
+        $items = Item::inRandomOrder()->take(2)->get();
+        SoldItem::insert([
+            [
+                'user_id' => $user->id,
+                'item_id' => $items[0]->id,
+                'payment_method_id' => 1,
+                'payment_intent_id' => 'pi_dummy_1',
+                'payment_completed' => 1,
+                'ship_name' => 'test',
+                'ship_postcode' => '1234567',
+                'ship_address' => 'test',
+            ],
+            [
+                'user_id' => 2,
+                'item_id' => $items[1]->id,
+                'payment_method_id' => 1,
+                'payment_intent_id' => 'pi_dummy_2',
+                'payment_completed' => 1,
+                'ship_name' => 'test',
+                'ship_postcode' => '1234567',
+                'ship_address' => 'test',
+            ],
+        ]);
+        $count = $user->purchasedItems->count();
+
+        $response = $this->actingAs($user)->get(route('mypage', ['filter' => 'purchased']));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($count) {
+            $page->component('MyPage')
+                 ->where('items.total', $count);
+        });
+    }
+}

--- a/tests/Feature/UserPage/ProfileTest.php
+++ b/tests/Feature/UserPage/ProfileTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Profile;
+
+class ProfileTest extends TestCase
+{
+    public function test_プロフィールページ表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('mypage.profile'));
+
+        $response->assertOk();
+    }
+
+    public function test_プロフィール編集処理(): void
+    {
+        $user = User::find(1);
+        $form = [
+            'name' => 'edited_'. $user->name,
+            'postcode' => '9999999',
+            'address' => 'edited_テスト住所 99-99-99',
+            'building' => 'edited_テスト建物名 9999号室',
+        ];
+
+        $response = $this->actingAs($user)->post(route('mypage.profile', $form));
+
+        $response->assertRedirect(route('mypage'));
+        $this->assertSame($user->name, $form['name']);
+        $this->assertDatabaseHas(Profile::class, [
+            'user_id' => $user->id,
+            'postcode' => '9999999',
+            'address' => 'edited_テスト住所 99-99-99',
+            'building' => 'edited_テスト建物名 9999号室',
+        ]);
+    }
+
+    public function test_画像アップロード(): void
+    {
+        $user = User::find(1);
+        Storage::fake('local');
+        $file = UploadedFile::fake()->image('test_'.Str::random(20).'.png');
+        $form = [
+            'name' => $user->name,
+            'image' => $file,
+        ];
+
+        $response = $this->actingAs($user)->post(route('mypage.profile'), $form);
+
+        $response->assertRedirect(route('mypage'));
+        $image_path = str_replace("/storage/img", "img", $user->profile->image_url);
+        Storage::disk('public')->assertExists($image_path);
+
+        // アップロードしたテスト用画像ファイルの削除
+        Storage::disk('public')->delete($image_path);
+    }
+}

--- a/tests/Feature/UserPage/PurchaseTest.php
+++ b/tests/Feature/UserPage/PurchaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+
+class PurchaseTest extends TestCase
+{
+    public function test_未ログイン状態で購入ページ表示した際のリダイレクト(): void
+    {
+        $item_id = Item::inRandomOrder()->first()->id;
+
+        $response = $this->get(route('purchase', $item_id));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_ログイン済み状態での購入ページ表示(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+
+        $response = $this->actingAs($user)->get(route('purchase', $item_id));
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/UserPage/RegisterShipAddressTest.php
+++ b/tests/Feature/UserPage/RegisterShipAddressTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Address;
+
+class RegisterShipAddressTest extends TestCase
+{
+    public function test_配送先登録ページ表示(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+
+        $response = $this->actingAs($user)->get(route('purchase.address.register', ['item_id' => $item_id]));
+
+        $response->assertOk();
+    }
+
+    public function test_配送先登録処理(): void
+    {
+        $user = User::find(1);
+        $item_id = Item::inRandomOrder()->first()->id;
+        $param = [
+            'item_id' => $item_id,
+            'user_id' => $user->id,
+            'name' => 'テスト配送先宛名',
+            'postcode' => '1234567',
+            'address' => 'テスト配送先住所 99-99-99',
+            'building' => 'テスト配送先建物名 9999号室',
+        ];
+
+        $response = $this->actingAs($user)->post(route('purchase.address.register', $param));
+
+        $response->assertRedirect(route('purchase', ['item_id' => $item_id, 'modalOpen' => true]));
+        $this->assertDatabaseHas(Address::class, [
+            'user_id' => $user->id,
+            'name' => 'テスト配送先宛名',
+            'postcode' => '1234567',
+            'address' => 'テスト配送先住所 99-99-99',
+            'building' => 'テスト配送先建物名 9999号室',
+        ]);
+    }
+}

--- a/tests/Feature/UserPage/SellTest.php
+++ b/tests/Feature/UserPage/SellTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Category;
+use App\Models\Category_item;
+
+class SellTest extends TestCase
+{
+    public function test_未ログイン状態で出品ページ表示した際のリダイレクト(): void
+    {
+        $response = $this->get(route('sell'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_ログイン済み状態での出品ページ表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('sell'));
+
+        $response->assertOk();
+    }
+
+    public function test_出品処理_出品した商品の存在確認(): void
+    {
+        $user = User::find(1);
+        Storage::fake('local');
+        $file = UploadedFile::fake()->image('test_'.Str::random(20).'.png');
+        $categories = Category::inRandomOrder()->take(3)->get()->pluck('id');
+        $form = [
+            'name' => 'テスト商品',
+            'brand' => 'テストブランド',
+            'price' => '99999',
+            'description' => 'テスト商品説明文',
+            'image' => $file,
+            'condition_id' => 1,
+            'categories' => $categories,
+        ];
+
+        $response = $this->actingAs($user)->post(route('sell'), $form);
+
+        $item = Item::latest('id')->first();
+        $image_path = str_replace("/storage/img", "img", $item->image_url);
+        $response->assertRedirect(route('item.detail', $item->id));
+        $this->assertDatabaseHas(Item::class, [
+            'name' => 'テスト商品',
+            'brand' => 'テストブランド',
+            'price' => '99999',
+            'description' => 'テスト商品説明文',
+            'condition_id' => 1,
+        ]);
+
+        // アップロードしたテスト用画像ファイルの削除
+        Storage::disk('public')->delete($image_path);
+    }
+
+    public function test_出品処理_商品画像ファイルの存在確認(): void
+    {
+        $user = User::find(1);
+        Storage::fake('local');
+        $file = UploadedFile::fake()->image('test_'.Str::random(20).'.png');
+        $categories = Category::inRandomOrder()->take(3)->get()->pluck('id');
+        $form = [
+            'name' => 'テスト商品',
+            'brand' => 'テストブランド',
+            'price' => '99999',
+            'description' => 'テスト商品説明文',
+            'image' => $file,
+            'condition_id' => 1,
+            'categories' => $categories,
+        ];
+
+        $response = $this->actingAs($user)->post(route('sell'), $form);
+
+        $item = Item::latest('id')->first();
+        $image_path = str_replace("/storage/img", "img", $item->image_url);
+        Storage::disk('public')->assertExists($image_path);
+
+        // アップロードしたテスト用画像ファイルの削除
+        Storage::disk('public')->delete($image_path);
+    }
+
+    public function test_出品処理_カテゴリーの登録確認(): void
+    {
+        $user = User::find(1);
+        Storage::fake('local');
+        $file = UploadedFile::fake()->image('test_'.Str::random(20).'.png');
+        $categories = Category::inRandomOrder()->take(3)->get()->pluck('id');
+        $form = [
+            'name' => 'テスト商品',
+            'brand' => 'テストブランド',
+            'price' => '99999',
+            'description' => 'テスト商品説明文',
+            'image' => $file,
+            'condition_id' => 1,
+            'categories' => $categories,
+        ];
+
+        $response = $this->actingAs($user)->post(route('sell'), $form);
+
+        $item = Item::latest('id')->first();
+        $image_path = str_replace("/storage/img", "img", $item->image_url);
+        $this->assertSame($categories->count(), $item->categories->count());
+
+        // アップロードしたテスト用画像ファイルの削除
+        Storage::disk('public')->delete($image_path);
+    }
+}

--- a/tests/Feature/UserPage/TopPageTest.php
+++ b/tests/Feature/UserPage/TopPageTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\UserPage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Category;
+use App\Models\Condition;
+use App\Models\Like;
+use Inertia\Testing\AssertableInertia;
+
+class TopPageTest extends TestCase
+{
+    public function test_未ログイン状態でのトップページ表示(): void
+    {
+        $response = $this->get(route('top'));
+
+        $response->assertOk();
+    }
+
+    public function test_ログイン済み状態でのトップページ表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('top'));
+
+        $response->assertOk();
+    }
+
+    public function test_未ログイン状態でマイリスト表示した際のリダイレクト(): void
+    {
+        $response = $this->get(route('top.mylist'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_ログイン済み状態でのマイリスト表示(): void
+    {
+        $user = User::find(1);
+
+        $response = $this->actingAs($user)->get(route('top.mylist'));
+
+        $response->assertOk();
+    }
+
+    public function test_トップページには全商品表示される()
+    {
+        $count = Item::all()->count();
+
+        $response = $this->get(route('top'));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($count) {
+            $page->component('Top')
+                 ->where('items.total', $count);
+        });
+    }
+
+    public function test_マイリストに表示されるのはお気に入り登録商品のみ(): void
+    {
+        $user = User::find(1);
+        $count = $user->likeItems->count();
+
+        $response = $this->actingAs($user)->get(route('top.mylist'));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($count) {
+            $page->component('Top')
+                 ->where('items.total', $count);
+        });
+    }
+
+    public function test_商品名での商品検索(): void
+    {
+        $search_word = Item::find(1)->name;
+
+        $response = $this->get(route('top', ['searchWord' => $search_word]));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($search_word) {
+            $page->component('Top')
+                 ->has('items.data.0', function (AssertableInertia $page) use ($search_word) {
+                    $page->where('name', $search_word)
+                         ->etc();
+                 });
+        });
+    }
+
+    public function test_商品説明文での商品検索(): void
+    {
+        $search_word = Item::find(1)->description;
+
+        $response = $this->get(route('top', ['searchWord' => $search_word]));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($search_word) {
+            $page->component('Top')
+                 ->has('items.data.0', function (AssertableInertia $page) use ($search_word) {
+                    $page->where('description', $search_word)
+                         ->etc();
+                 });
+        });
+    }
+
+    public function test_カテゴリ名での商品検索(): void
+    {
+        $category = Category::find(1);
+        $search_word = $category->name;
+        $count = $category->items->count();
+
+        $response = $this->get(route('top', ['searchWord' => $search_word]));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($count) {
+            $page->component('Top')
+                 ->where('items.total', $count);
+        });
+    }
+
+    public function test_商品状態での商品検索(): void
+    {
+        $condition = Condition::find(1);
+        $search_word = $condition->name;
+        $count = $condition->items->count();
+
+        $response = $this->get(route('top', ['searchWord' => $search_word]));
+
+        $response->assertInertia(function (AssertableInertia $page) use ($count) {
+            $page->component('Top')
+                 ->where('items.total', $count);
+        });
+    }
+
+    public function test_お気に入り登録(): void
+    {
+        $user = User::find(1);
+        $item = Item::create([
+            'name' => 'test',
+            'price' => '1000',
+            'description' => 'test',
+            'image_url' => '/img/dummy_item.png',
+            'condition_id' => '1',
+            'user_id' => '1',
+            'stripe_price_id' => 'price_dummy',
+        ]);
+
+        $response = $this->actingAs($user)->post('api/like/'.$item->id);
+
+        $response->assertOk();
+        $this->assertDatabaseHas(Like::class, [
+            'user_id' => 1,
+            'item_id' => $item->id,
+        ]);
+    }
+
+    public function test_お気に入り削除(): void
+    {
+        $like = Like::latest('id')->first();
+        $user = User::find($like->user_id);
+
+        $response = $this->actingAs($user)->delete('api/like/'.$like->item_id);
+
+        $response->assertOk();
+        $this->assertDatabaseMissing(Like::class, [
+            'id' => $like->id,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,13 @@
 
 namespace Tests;
 
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use RefreshDatabase;
+
+    protected string $seeder = DatabaseSeeder::class;
 }


### PR DESCRIPTION
## 【概要】
ユーザー向けページのテストコードを実装

## 【実装内容詳細】
- テスト開始時に必要なテーブルのシーディングを行うよう TestCase.php に処理を追記
- 各ページ毎に基本機能をテストするためのテストクラスを作成
	- TopPageTest
	- ItemDetailTest
	- CommentTest
	- PurchaseTest
	- RegisterShipAddressTest
	- EditShipAddressTest
	- MyPageTest
	- ProfileTest
	- SellTest