### PR TITLE
Fix/issue#027

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -32,6 +32,11 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        // メール認証が完了していない状態でログインした場合は「確認メール送信しました」ページへリダイレクト
+        if (Auth::user()->email_verified_at === null) {
+            return redirect(route('verification.notice'));
+        }
+
         return redirect()->intended(route('top', absolute: false));
     }
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -49,7 +49,7 @@ class AuthenticationTest extends TestCase
         $user = User::create([
             'role_id' => '2',
             'name' => 'Test User',
-            'email' => 'test@example.com',
+            'email' => 'test2@example.com',
             'password' => Hash::make('password'),
             'remember_token' => Str::random(10),
         ]);


### PR DESCRIPTION
## 【概要】
メール認証が完了していない状態でログインした際に「確認メール送信しました」ページへリダイレクトするように処理を追加

## 【実装内容詳細】
- ログイン処理メソッド（AuthenticatedSessionController::class, store）内で "メール認証済みかどうか" の判定を追加し、認証していなければリダイレクトするように処理を追記
- 上記修正に合わせてテストコード（Feature/Admin/AuthenticationTest）を調整