### PR TITLE
Fix/issue#028

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -21,18 +21,6 @@ Route::middleware('guest')->group(function () {
         ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
-
-    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-        ->name('password.request');
-
-    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-        ->name('password.email');
-
-    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-        ->name('password.reset');
-
-    Route::post('reset-password', [NewPasswordController::class, 'store'])
-        ->name('password.store');
 });
 
 Route::middleware('auth')->group(function () {
@@ -47,13 +35,6 @@ Route::middleware('auth')->group(function () {
         ->middleware('throttle:6,1')
         ->name('verification.send');
 
-    Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-        ->name('password.confirm');
-
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
-
-    Route::put('password', [PasswordController::class, 'update'])->name('password.update');
-
-    Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
+        Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');
 });

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -35,6 +35,6 @@ Route::middleware('auth')->group(function () {
         ->middleware('throttle:6,1')
         ->name('verification.send');
 
-        Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
+    Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');
 });


### PR DESCRIPTION
## 【概要】
Breezeデフォルトで用意されている認証関連ルーティングの中で不要なものが多数あったため、それらを削除

## 【実装内容詳細】
- 以下ルーティングを削除
	- パスワード忘れページ表示
	- パスワード忘れ時の再設定
	- パスワードリセットページ表示
	- パスワードリセット処理
	- パスワード確認ページ表示
	- パスワード確認処理
	- パスワード変更処理