### PR TITLE
Fix/issue#032

### DIFF
--- a/app/Http/Controllers/Admin/AdminCommentController.php
+++ b/app/Http/Controllers/Admin/AdminCommentController.php
@@ -25,9 +25,9 @@ class AdminCommentController extends Controller
     public function index(Request $request): Response {
         $searchParam = $request->searchParam;
         $id = $searchParam['id'] ?? null;
-        $item_name = $searchParam['itemName'] ?? null;
-        $user_name = $searchParam['userName'] ?? null;
-        $comment = $searchParam['comment'] ?? null;
+        $item_name = addcslashes($searchParam['itemName'] ?? null, '%_\\');
+        $user_name = addcslashes($searchParam['userName'] ?? null, '%_\\');
+        $comment = addcslashes($searchParam['comment'] ?? null, '%_\\');
         $date = $searchParam['date'] ?? null;
 
         $comments = Comment::idSearch($id)

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -25,8 +25,8 @@ class AdminUserController extends Controller
     public function index(Request $request): Response {
         $searchParam = $request->searchParam;
         $id = $searchParam['id'] ?? null;
-        $name = $searchParam['name'] ?? null;
-        $email = $searchParam['email'] ?? null;
+        $name = addcslashes($searchParam['name'] ?? null, '%_\\');
+        $email = addcslashes($searchParam['email'] ?? null, '%_\\');
         $date = $searchParam['date'] ?? null;
 
         $users = User::searchId($id)

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -102,7 +102,7 @@ class Comment extends Model
      * @return Builder|Comment
      */
     public function scopeIdSearch(Builder $query, int|null $id): Builder|Comment {
-        if (!empty($id)) {
+        if (isset($id)) {
             return $query->where('id', $id);
         } else {
             return $query;
@@ -117,7 +117,7 @@ class Comment extends Model
      * @return Builder|Comment
      */
     public function scopeItemNameSearch(Builder $query, string|null $item_name): Builder|Comment {
-        if (!empty($item_name)) {
+        if (isset($item_name)) {
             $ids = Item::where('name', 'like', "%{$item_name}%")->get()->pluck('id');
             return $query->whereIn('item_id', $ids);
         } else {
@@ -133,7 +133,7 @@ class Comment extends Model
      * @return Builder|Comment
      */
     public function scopeUserNameSearch(Builder $query, string|null $user_name): Builder|Comment {
-        if (!empty($user_name)) {
+        if (isset($user_name)) {
             $ids = User::where('name', 'like', "%{$user_name}%")->get()->pluck('id');
             return $query->whereIn('user_id', $ids);
         } else {
@@ -149,7 +149,7 @@ class Comment extends Model
      * @return Builder|Comment
      */
     public function scopeCommentSearch(Builder $query, string|null $comment): Builder|Comment {
-        if (!empty($comment)) {
+        if (isset($comment)) {
             return $query->where('comment', 'like', "%{$comment}%");
         } else {
             return $query;
@@ -164,7 +164,7 @@ class Comment extends Model
      * @return Builder|Comment
      */
     public function scopeCreatedAtSearch(Builder $query, string|null $date): Builder|Comment {
-        if (!empty($date)) {
+        if (isset($date)) {
             return $query->where('created_at', 'like', "{$date}%");
         } else {
             return $query;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -213,7 +213,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * @return Builder|User
      */
     public function scopeSearchId(Builder $query, int|null $id): Builder|User {
-        if (!empty($id)) {
+        if (isset($id)) {
             return $query->where('id', $id);
         } else {
             return $query;
@@ -228,7 +228,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * @return Builder|User
      */
     public function scopeSearchName(Builder $query, string|null $name): Builder|User {
-        if (!empty($name)) {
+        if (isset($name)) {
             return $query->where('name', 'like', "%{$name}%");
         } else {
             return $query;
@@ -243,7 +243,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * @return Builder|User
      */
     public function scopeSearchEmail(Builder $query, string|null $email): Builder|User {
-        if (!empty($email)) {
+        if (isset($email)) {
             return $query->where('email', 'like', "%{$email}%");
         } else {
             return $query;
@@ -258,7 +258,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * @return Builder|User
      */
     public function scopeSearchCreateAt(Builder $query, string|null $date): Builder|User {
-        if (!empty($date)) {
+        if (isset($date)) {
             return $query->where('created_at', 'like', "{$date}%");
         } else {
             return $query;

--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -103,6 +103,7 @@ class ItemService
      */
     public function searchItemsWithLike(string $search_word) : Collection {
         // [商品名] [商品説明文] 検索
+        $search_word = addcslashes($search_word, '%_\\');
         $this->items = Item::where('name', 'like', "%{$search_word}%")
                            ->orWhere('description', 'like', "%{$search_word}%")
                            ->get();

--- a/tests/Feature/UserPage/TopPageTest.php
+++ b/tests/Feature/UserPage/TopPageTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\UserPage;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\Item;
@@ -103,32 +104,40 @@ class TopPageTest extends TestCase
 
     public function test_商品名での商品検索(): void
     {
-        $search_word = Item::find(1)->name;
+        $search_word = mb_substr(Item::inRandomOrder()->first()->name, -2);
 
         $response = $this->get(route('top', ['searchWord' => $search_word]));
 
-        $response->assertInertia(function (AssertableInertia $page) use ($search_word) {
-            $page->component('Top')
-                 ->has('items.data.0', function (AssertableInertia $page) use ($search_word) {
-                    $page->where('name', $search_word)
-                         ->etc();
-                 });
-        });
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Top')
+            ->has('items.data', fn (AssertableInertia $page) => $page
+                ->each(fn (AssertableInertia $page) => $page
+                    ->where('name', function ($name) use ($search_word) {
+                        return Str::contains($name, $search_word);
+                    })
+                    ->etc()
+                )
+            )
+        );
     }
 
     public function test_商品説明文での商品検索(): void
     {
-        $search_word = Item::find(1)->description;
+        $search_word = mb_substr(Item::inRandomOrder()->first()->description, -2);
 
         $response = $this->get(route('top', ['searchWord' => $search_word]));
 
-        $response->assertInertia(function (AssertableInertia $page) use ($search_word) {
-            $page->component('Top')
-                 ->has('items.data.0', function (AssertableInertia $page) use ($search_word) {
-                    $page->where('description', $search_word)
-                         ->etc();
-                 });
-        });
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Top')
+            ->has('items.data', fn (AssertableInertia $page) => $page
+                ->each(fn (AssertableInertia $page) => $page
+                    ->where('description', function ($description) use ($search_word) {
+                        return Str::contains($description, $search_word);
+                    })
+                    ->etc()
+                )
+            )
+        );
     }
 
     public function test_カテゴリ名での商品検索(): void


### PR DESCRIPTION
## 【概要】
文字列検索フォームに「0」「％」「＿」を入力した場合に全件ヒットしてしまう問題を修正

## 【実装内容詳細】
- 以下モデルの検索処理用ローカルスコープメソッドについて、「0」が入力された場合にif文で弾かれて除外されていた問題を修正（`!empty`を`isset`に変更）
	- Userモデルのローカルスコープ
	- Commentモデルのローカルスコープ
- 以下コントローラーで文字列検索する際、ワイルドカード扱いになる特定記号をエスケープするように処理を追記
	- ItemService
	- AdminUserController
	- AdminCommentController
- TopPageTestの商品検索関連テストコードを調整