### PR TITLE
マイページでログアウトした際にヘッダーのナビメニューが更新されない問題を修正

### DIFF
--- a/resources/js/Layouts/DefaultLayout.vue
+++ b/resources/js/Layouts/DefaultLayout.vue
@@ -1,12 +1,13 @@
 <script setup>
+import { computed } from 'vue'
 import { Head, Link, usePage } from '@inertiajs/vue3';
 import ApplicationLogo from '@/Components/ApplicationLogo.vue';
 import NavLink from '@/Components/NavLink.vue';
 import SearchItems from "@/Components/SearchItems.vue";
 import HamburgerMenu from "@/Components/UserHamburgerMenu.vue";
 
-const isLogined = (usePage().props.auth.user !== null);
-const isAdmin = (isLogined === true) && (usePage().props.auth.user.role_id === 1);
+const isLogined = computed(() => (usePage().props.auth.user !== null));
+const isAdmin = computed(() => (usePage().props.auth.user !== null) && (usePage().props.auth.user.role_id === 1));
 </script>
 
 <template>


### PR DESCRIPTION
## 【概要】
マイページでログアウトした際にヘッダーのナビメニューが更新されない問題を修正

## 【実装内容詳細】
- DefaultLayout.vueの「ログインフラグ」及び「管理者フラグ」について、変更を検知して即時反映されるように算出プロパティを追記