### PR TITLE
管理ページのテストコードにて「年月日での検索」関連のテストが特定条件で失敗する問題を修正

### DIFF
--- a/tests/Feature/AdminPage/AdminCommentTest.php
+++ b/tests/Feature/AdminPage/AdminCommentTest.php
@@ -139,7 +139,9 @@ class AdminCommentTest extends TestCase
             ->where('comments.total', $count)
             ->has('comments.data', fn (AssertableInertia $page) => $page
                 ->each(fn (AssertableInertia $page) => $page
-                    ->where('created_at', $test_date_time)
+                    ->where('created_at', function ($created_at) use ($test_param) {
+                        return Str::contains($created_at, $test_param);
+                    })
                     ->etc()
                 )
             )

--- a/tests/Feature/AdminPage/AdminUserTest.php
+++ b/tests/Feature/AdminPage/AdminUserTest.php
@@ -100,14 +100,18 @@ class AdminUserTest extends TestCase
 
         $response = $this->actingAs($user)->get(route('admin.user', ['searchParam' => $search_param]));
 
-        $response->assertInertia(function (AssertableInertia $page) use ($test_date_time, $count) {
-            $page->component('Admin/AdminUser')
-                 ->where('users.total', $count)
-                 ->has('users.data.0', function (AssertableInertia $page) use ($test_date_time) {
-                    $page->where('created_at', $test_date_time)
-                         ->etc();
-                 });
-        });
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Admin/AdminUser')
+        ->where('users.total', $count)
+        ->has('users.data', fn (AssertableInertia $page) => $page
+            ->each(fn (AssertableInertia $page) => $page
+                ->where('created_at', function ($created_at) use ($test_param) {
+                    return Str::contains($created_at, $test_param);
+                })
+                ->etc()
+            )
+        )
+    );
     }
 
     public function test_ユーザー削除(): void


### PR DESCRIPTION
## 【概要】
管理ページのテストコードにて「年月日での検索」関連のテストが特定条件で失敗する問題を修正

## 【実装内容詳細】
- 以下ファイルの「登録日／投稿日での検索」関連テストコードにおいて、"時分秒" まで一致を確認しており意図しないエラーとなるパターンがあった為、"年月日" までの確認にするよう修正
	- AdminUserTest.php
	- AdminCommentTest.php