### PR TITLE
デプロイ用のexecutorsを修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ executors:
           TZ: Asia/Tokyo
 
   base:
-    machine:
-      image: cimg/base:2025.02
+    docker:
+      - image: cimg/base:2025.02
 
 commands:
   run_test:


### PR DESCRIPTION
## 【概要】
デプロイ用のexecutorsの記述に誤りがあったため修正