### PR TITLE
テスト時まれに「該当データが無い」状況が発生してしまう問題を修正

### DIFF
--- a/tests/Feature/AdminPage/AdminCommentTest.php
+++ b/tests/Feature/AdminPage/AdminCommentTest.php
@@ -54,7 +54,7 @@ class AdminCommentTest extends TestCase
     public function test_商品名でのコメント検索(): void
     {
         $user = User::where('role_id', 1)->first();
-        $test_param = 'ダミー商品_' . rand(1, 5);
+        $test_param = 'ダミー商品_' . rand(1, 4);
         $search_param = [
             'itemName' => $test_param,
         ];

--- a/tests/Feature/UserPage/TopPageTest.php
+++ b/tests/Feature/UserPage/TopPageTest.php
@@ -75,6 +75,10 @@ class TopPageTest extends TestCase
     public function test_マイリストに表示されるのはお気に入り登録商品のみ(): void
     {
         $user = User::find(1);
+        Like::create([
+            'user_id' => $user->id,
+            'item_id' => Item::where('user_id', '!=', $user->id)->inRandomOrder()->first()->id,
+        ]);
 
         $response = $this->actingAs($user)->get(route('top.mylist'));
 
@@ -92,6 +96,16 @@ class TopPageTest extends TestCase
     public function test_マイリストには自身の出品商品を除外して表示される(): void
     {
         $user = User::find(1);
+        Like::insert([
+            [
+                'user_id' => $user->id,
+                'item_id' => Item::where('user_id', '!=', $user->id)->inRandomOrder()->first()->id,
+            ],
+            [
+                'user_id' => $user->id,
+                'item_id' => Item::where('user_id', $user->id)->inRandomOrder()->first()->id,
+            ]
+        ]);
         $count = $user->likeItems->where('user_id', '!=', $user->id)->count();
 
         $response = $this->actingAs($user)->get(route('top.mylist'));


### PR DESCRIPTION
## 【概要】
「コメント」や「お気に入り」のシーディングにてランダム登録している為、テスト時に稀に「該当データが無い」という状況が発生し、その場合にテスト失敗してしまう問題を修正

## 【実装内容詳細】
- TopPageTest.phpの「マイリストに表示されるのはお気に入り登録商品のみ」テストにて、先にお気に入りデータを登録してからテストするように修正
- AdminCommentTest.phpの「商品名でのコメント検索」テストにて、入力値を「ダミー商品_1」～「ダミー商品_4」とするよう修正
（※「ダミー商品_5」も含めていたが、この入力だとコメントが無い可能性が高かったため除外）