### PR TITLE
APIエラーレスポンスのステータスコードを変更

### DIFF
--- a/app/Http/Controllers/Api/PaymentIntentController.php
+++ b/app/Http/Controllers/Api/PaymentIntentController.php
@@ -34,7 +34,6 @@ class PaymentIntentController extends Controller
                 $ship_postcode = $user->profile->postcode;
                 $ship_address = $user->profile->address;
                 if (!$ship_postcode || !$ship_address) {
-                    Log::info('住所なしエラー');
                     return response()->json([
                         'status' => 'error',
                         'message' => '配送先が正しく登録されていません'
@@ -91,7 +90,7 @@ class PaymentIntentController extends Controller
             return response()->json([
                 'status' => 'error',
                 'message' => 'エラーが発生しました'
-            ], 500);
+            ], 400);
         }
     }
 }

--- a/app/Http/Controllers/Api/SoldItemController.php
+++ b/app/Http/Controllers/Api/SoldItemController.php
@@ -36,7 +36,7 @@ class SoldItemController extends Controller
             return response()->json([
                 'status' => 'error',
                 'message' => 'エラーが発生しました'
-            ], 500);
+            ], 400);
         }
     }
 
@@ -91,7 +91,7 @@ class SoldItemController extends Controller
             return response()->json([
                 'status' => 'error',
                 'message' => 'エラーが発生しました'
-            ], 500);
+            ], 400);
         }
     }
 
@@ -113,7 +113,7 @@ class SoldItemController extends Controller
             return response()->json([
                 'status' => 'error',
                 'message' => 'エラーが発生しました'
-            ], 500);
+            ], 400);
         }
     }
 }


### PR DESCRIPTION
## 【概要】
APIでのエラー発生時、空のエラーメッセージモーダルが表示される問題を修正

## 【実装内容詳細】
- APIがエラーを返す際のステータスコードを「500」から「400」へ修正