### PR TITLE
出品時の販売価格上限を「300000円」に変更

### DIFF
--- a/app/Http/Requests/ItemRegisterRequest.php
+++ b/app/Http/Requests/ItemRegisterRequest.php
@@ -36,7 +36,7 @@ class ItemRegisterRequest extends FormRequest
             'name' => ['required', 'string', 'max:100'],
             'brand' => ['nullable', 'string', 'max:50'],
             'description' => ['required', 'string', 'max:1000'],
-            'price' => ['required', 'numeric', 'integer', 'min:300', 'max:9999999'],
+            'price' => ['required', 'numeric', 'integer', 'min:300', 'max:300000'],
         ];
     }
 

--- a/tests/Feature/UserPage/SellTest.php
+++ b/tests/Feature/UserPage/SellTest.php
@@ -247,17 +247,17 @@ class SellTest extends TestCase
                 ],
                 'expected' => ['price' => '300円以上の価格を設定してください'],
             ],
-            '販売価格に10,000,000円以上を入力' => [
+            '販売価格に300,000円以上を入力' => [
                 'form' => [
                     'name' => 'テスト商品',
                     'brand' => 'テストブランド',
-                    'price' => 10000000,
+                    'price' => 300001,
                     'description' => 'テスト商品説明文',
                     'image' => UploadedFile::fake()->image('test.png'),
                     'condition_id' => 1,
                     'categories' => [1, 2, 3],
                 ],
-                'expected' => ['price' => '9999999円以下の価格を設定してください'],
+                'expected' => ['price' => '300000円以下の価格を設定してください'],
             ],
             '画像に画像ファイル以外を指定' => [
                 'form' => [


### PR DESCRIPTION
## 【概要】
出品時の販売価格上限を「300000円」に変更
※コンビニ払いの上限額が「300000円」である為それに合わせる形へ修正

## 【実装内容詳細】
- 商品出品時のバリデーションにおいて販売価格のmax値を 'max:300000' へ変更
	- ItemRegisterRequest.php
- SellTest.php のバリデーションテストを上記変更に沿うよう調整