### PR TITLE
メールアドレス入力のバリデーション矛盾を修正

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -34,7 +34,7 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
+            'email' => 'required|string|lowercase|email|max:254|unique:'.User::class,
             'password' => [
                 'required',
                 'string',


### PR DESCRIPTION
## 【概要】
「会員登録時」と「ログイン時」のメールアドレス入力のバリデーションに矛盾があった問題を修正

## 【実装内容詳細】
- RegisteredUserController内のバリデーションにて、メールアドレスの最大文字数をログイン時と同じ「254」に修正