### PR TITLE
ボタン連打対策が漏れていた箇所を修正

### DIFF
--- a/resources/js/Components/LikeIcon.vue
+++ b/resources/js/Components/LikeIcon.vue
@@ -1,22 +1,31 @@
 <script setup>
+import { ref } from 'vue'
 import { router } from '@inertiajs/vue3'
 
 const props = defineProps({
     item: Object,
 })
 
+const processing = ref(false);
+
 function ChangeLike() {
+    // ボタン無効化
+    processing.value = true;
+
+    // お気に入り変更処理
     if (props.item.is_like) {
         // お気に入り削除
         router.delete(`/api/like/${props.item.id}`, {
             preserveScroll: true,
             onError: (errors) => {console.log( errors ) },
+            onFinish: () => {processing.value = false},
         });
     } else {
         // お気に入り登録
         router.post(`/api/like/${props.item.id}`, {}, {
             preserveScroll: true,
             onError: (errors) => {console.log( errors ) },
+            onFinish: () => {processing.value = false},
         });
     }
 }
@@ -24,7 +33,7 @@ function ChangeLike() {
 
 <template>
     <div class="inline-block text-center">
-        <button @click="ChangeLike()" class="flex justify-center items-center">
+        <button @click="ChangeLike()" class="flex justify-center items-center" :disabled="processing">
             <img v-if="item.is_like" :src="'/img/like_on.svg'" alt="" class="w-8">
             <img v-else :src="'/img/like_off.svg'" alt="" class="w-8">
         </button>

--- a/resources/js/Pages/Admin/AdminMail.vue
+++ b/resources/js/Pages/Admin/AdminMail.vue
@@ -53,7 +53,12 @@ function submit() {
                 </div>
             </div>
             <div class="pt-8">
-                <PrimaryButton>送信する</PrimaryButton><br>
+                <PrimaryButton
+                    :class="{ 'opacity-25': form.processing }"
+                    :disabled="form.processing"
+                >
+                    送信する
+                </PrimaryButton><br>
             </div>
         </form>
 

--- a/resources/js/Pages/Comment.vue
+++ b/resources/js/Pages/Comment.vue
@@ -62,7 +62,12 @@ function submit() {
                         <!-- <InputError class="mt-2" :message="form.errors.comment" /> -->
                         <TextAreaInput v-model="form.comment" required />
                         <InputError class="mb-2" :message="form.errors.comment" />
-                        <PrimaryButton>コメントを送信する</PrimaryButton>
+                        <PrimaryButton
+                            :class="{ 'opacity-25': form.processing }"
+                            :disabled="form.processing"
+                        >
+                            コメントを送信する
+                        </PrimaryButton>
                     </form>
                 </div>
             </div>

--- a/resources/js/Pages/EditShipAddress.vue
+++ b/resources/js/Pages/EditShipAddress.vue
@@ -50,7 +50,12 @@ function submit() {
                 <InputError class="mt-2" :message="form.errors.building" />
             </div>
             <div class="pt-16">
-                <PrimaryButton>更新する</PrimaryButton><br>
+                <PrimaryButton
+                    :class="{ 'opacity-25': form.processing }"
+                    :disabled="form.processing"
+                >
+                    更新する
+                </PrimaryButton><br>
             </div>
         </form>
     </div>

--- a/resources/js/Pages/Profile.vue
+++ b/resources/js/Pages/Profile.vue
@@ -65,7 +65,12 @@ function submit() {
                 <InputError class="mt-2" :message="form.errors.building" />
             </div>
             <div class="pt-16">
-                <PrimaryButton>更新する</PrimaryButton><br>
+                <PrimaryButton
+                    :class="{ 'opacity-25': form.processing }"
+                    :disabled="form.processing"
+                >
+                    更新する
+                </PrimaryButton><br>
             </div>
         </form>
     </div>

--- a/resources/js/Pages/RegisterShipAddress.vue
+++ b/resources/js/Pages/RegisterShipAddress.vue
@@ -49,7 +49,12 @@ function submit() {
                 <InputError class="mt-2" :message="form.errors.building" />
             </div>
             <div class="pt-16">
-                <PrimaryButton>登録する</PrimaryButton><br>
+                <PrimaryButton
+                    :class="{ 'opacity-25': form.processing }"
+                    :disabled="form.processing"
+                >
+                    登録する
+                </PrimaryButton><br>
             </div>
         </form>
     </div>

--- a/resources/js/Pages/Sell.vue
+++ b/resources/js/Pages/Sell.vue
@@ -94,7 +94,12 @@ function imageReset() {
                 <InputError class="mt-2" :message="form.errors.price" />
             </div>
             <div class="pt-16">
-                <PrimaryButton>出品する</PrimaryButton><br>
+                <PrimaryButton
+                    :class="{ 'opacity-25': form.processing }"
+                    :disabled="form.processing"
+                >
+                    出品する
+                </PrimaryButton><br>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## 【概要】
ボタン連打対策が漏れていた箇所を修正

## 【実装内容詳細】
以下箇所にてボタン連打した際、2度目以降が無効となるよう修正
- お気に入りボタン
- 出品ボタン
- プロフィール変更ボタン
- 配送先登録ボタン
- 配送先編集ボタン
- コメント投稿ボタン
- Adminメールの送信ボタン