### PR TITLE
商品購入が完了した後に意図しないページに飛ぶ問題を修正

### DIFF
--- a/app/Http/Controllers/PurchaseController.php
+++ b/app/Http/Controllers/PurchaseController.php
@@ -69,7 +69,7 @@ class PurchaseController extends Controller
             $stripe = new StripeClient(config('stripe.stripe_secret'));
 
             // sold_itemレコードが意図したものか念のため確認
-            if ($sold_item->user_id !== $request->user()->id || $sold_item->item_id !== $request->item_id) {
+            if ($sold_item->user_id !== $request->user()->id || $sold_item->item_id != $request->item_id) {
                 return to_route('top');
             }
 


### PR DESCRIPTION
## 【概要】
sold_itemレコードが意図したものか確認する際の判定にて「文字列」と「数値」の比較が行われている事により
意図しない判定結果になっていた箇所が有った為、このif文の判定を修正

## 【実装内容詳細】
- !== で判定していた部分を != へと変更